### PR TITLE
dededuplicate

### DIFF
--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
 
 
 # =======================
-# ***  deplete_human  ***
+# ***  deplete  ***
 # =======================
 
 def parser_deplete(parser=argparse.ArgumentParser()):
@@ -49,9 +49,8 @@ def parser_deplete(parser=argparse.ArgumentParser()):
     parser.add_argument('revertBam', nargs='?', help='Output BAM: read markup reverted with Picard.')
     parser.add_argument('bwaBam', help='Output BAM: depleted of reads with BWA.')
     parser.add_argument('bmtaggerBam', help='Output BAM: depleted of reads with BMTagger.')
-    parser.add_argument('rmdupBam', help='Output BAM: bmtaggerBam run through M-Vicuna duplicate removal.')
     parser.add_argument(
-        'blastnBam', help='Output BAM: rmdupBam run through another depletion of reads with BLASTN.'
+        'blastnBam', help='Output BAM: bmtaggerBam run through another depletion of reads with BLASTN.'
     )
     parser.add_argument(
         '--bwaDbs',
@@ -86,10 +85,8 @@ def parser_deplete(parser=argparse.ArgumentParser()):
 
     return parser
 
-
-
 def main_deplete(args):
-    ''' Run the entire depletion pipeline: bwa, bmtagger, mvicuna, blastn.
+    ''' Run the entire depletion pipeline: bwa, bmtagger, blastn.
     '''
 
     assert len(args.bmtaggerDbs) + len(args.blastDbs) + len(args.bwaDbs) > 0
@@ -134,9 +131,8 @@ def main_deplete(args):
     if not args.revertBam:
         os.unlink(revertBamOut)
 
-    read_utils.rmdup_mvicuna_bam(args.bmtaggerBam, args.rmdupBam, JVMmemory=args.JVMmemory)
     multi_db_deplete_bam(
-        args.rmdupBam,
+        args.bmtaggerBam,
         args.blastDbs,
         deplete_blastn_bam,
         args.blastnBam,
@@ -148,18 +144,6 @@ def main_deplete(args):
 
 __commands__.append(('deplete', parser_deplete))
 
-
-def parser_deplete_human(parser=argparse.ArgumentParser()):
-    parser = parser_deplete(parser)
-    util.cmd.attach_main(parser, main_deplete_human)
-
-    return parser
-
-def main_deplete_human(args):
-    ''' A wrapper around 'deplete'; deprecated but preserved for legacy compatibility.
-    '''
-    main_deplete(args)
-__commands__.append(('deplete_human', parser_deplete_human))
 
 # =======================
 # ***  filter_lastal  ***

--- a/test/unit/test_integration_taxon_filter.py
+++ b/test/unit/test_integration_taxon_filter.py
@@ -52,7 +52,6 @@ class TestDepleteHuman(TestCaseWithTmp):
                 os.path.join(self.tempDir, 'test-reads.revert.bam'),
                 os.path.join(self.tempDir, 'test-reads.bwa.bam'),
                 os.path.join(self.tempDir, 'test-reads.bmtagger.bam'),
-                os.path.join(self.tempDir, 'test-reads.rmdup.bam'),
                 os.path.join(self.tempDir, 'test-reads.blastn.bam'),
                 # DBs
                 "--blastDbs", self.blastdb_path,
@@ -68,7 +67,6 @@ class TestDepleteHuman(TestCaseWithTmp):
             'test-reads.revert.bam', 
             'test-reads.bwa.bam',
             'test-reads.bmtagger.bam',
-            'test-reads.rmdup.bam', 
             'test-reads.blastn.bam'
         ]:
             assert_equal_bam_reads(self, os.path.join(self.tempDir, fname), os.path.join(myInputDir, 'expected', fname))
@@ -84,7 +82,6 @@ class TestDepleteHuman(TestCaseWithTmp):
                 os.path.join(self.tempDir, 'test-reads.revert.bam'),
                 os.path.join(self.tempDir, 'test-reads.bwa.bam'),
                 os.path.join(self.tempDir, 'test-reads.bmtagger.bam'),
-                os.path.join(self.tempDir, 'test-reads.rmdup.bam'),
                 os.path.join(self.tempDir, 'test-reads.blastn.bam'),
                 # DBs
                 "--blastDbs", self.blastdb_path,
@@ -99,7 +96,6 @@ class TestDepleteHuman(TestCaseWithTmp):
             'test-reads.revert.bam', 
             'test-reads.bwa.bam',
             'test-reads.bmtagger.bam',
-            'test-reads.rmdup.bam', 
             'test-reads.blastn.bam'
         ]:
             assert_equal_bam_reads(self, os.path.join(self.tempDir, fname), os.path.join(myInputDir, 'aligned-expected', fname))
@@ -115,7 +111,6 @@ class TestDepleteHuman(TestCaseWithTmp):
                 os.path.join(self.tempDir, 'deplete-empty.revert.bam'),
                 os.path.join(self.tempDir, 'deplete-empty.bwa.bam'),
                 os.path.join(self.tempDir, 'deplete-empty.bmtagger.bam'),
-                os.path.join(self.tempDir, 'deplete-empty.rmdup.bam'),
                 os.path.join(self.tempDir, 'deplete-empty.blastn.bam'),
                 # DBs
                 "--blastDbs", self.blastdb_path,
@@ -127,7 +122,6 @@ class TestDepleteHuman(TestCaseWithTmp):
 
         # Compare to expected
         for fname in [
-            'deplete-empty.bmtagger.bam',
-            'deplete-empty.rmdup.bam', 'deplete-empty.blastn.bam',
+            'deplete-empty.bmtagger.bam', 'deplete-empty.blastn.bam',
         ]:
             assert_equal_bam_reads(self, os.path.join(self.tempDir, fname), empty_bam)


### PR DESCRIPTION
Removes mvicuna invocation from taxon_filter.deplete. Closes #8 