### PR TITLE
kraken2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV VIRAL_CLASSIFY_PATH=$INSTALL_PATH/viral-classify \
 
 COPY requirements-conda.txt requirements-conda-env2.txt $VIRAL_CLASSIFY_PATH/
 RUN $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda.txt 
-RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env2"; conda create -q -y -n $CONDA_PREFIX; $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env2.txt 
+RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env2"; conda create -q -y -n env2; $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env2.txt
 
 # Copy all source code into the base repo
 # (this probably changes all the time, so all downstream build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM quay.io/broadinstitute/viral-core:2.0.21
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 
-ENV VIRAL_CLASSIFY_PATH=$INSTALL_PATH/viral-classify
+ENV VIRAL_CLASSIFY_PATH=$INSTALL_PATH/viral-classify \
+	PATH="$PATH:$MINICONDA_PATH/envs/env2/bin"
 
-COPY requirements-conda.txt $VIRAL_CLASSIFY_PATH/
-RUN $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda.txt
+COPY requirements-conda.txt requirements-conda-env2.txt $VIRAL_CLASSIFY_PATH/
+RUN $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda.txt 
+RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env2"; conda create -q -y -n $CONDA_PREFIX; $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env2.txt 
 
 # Copy all source code into the base repo
 # (this probably changes all the time, so all downstream build

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -1,0 +1,199 @@
+'''
+KRAKEN metagenomics classifier
+'''
+import collections
+import itertools
+import logging
+import os
+import os.path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import tools
+import tools.picard
+import tools.samtools
+import util.file
+import util.misc
+from builtins import super
+
+log = logging.getLogger(__name__)
+
+class Kraken2(tools.Tool):
+
+    def __init__(self, install_methods=None):
+        if not install_methods:
+            install_methods = []
+            install_methods.append(tools.PrexistingUnixCommand('kraken2', verifycmd=False, require_executability=False))
+        super(Kraken2, self).__init__(install_methods=install_methods)
+
+    def version(self):
+        return '2'
+
+    @property
+    def libexec(self):
+        if not self.executable_path():
+            self.install_and_get_path()
+        return os.path.dirname(self.executable_path())
+
+    def build(self, db, standard_libraries=(), custom_libraries=(), taxdump_out=None,
+        k=None, l=None, s=None, protein=False, max_db_size=None, num_threads=None):
+        '''Create a kraken database.
+
+        Args:
+          db: Kraken database directory to build. Must have library/ and
+            taxonomy/ subdirectories to build from.
+          standard_libraries: a list of strings from the set of:
+             "archaea", "bacteria", "plasmid",
+             "viral", "human", "fungi", "plant", "protozoa",
+             "nr", "nt", "env_nr", "env_nt", "UniVec",
+             "UniVec_Core"
+          *args: List of input filenames to process.
+        '''
+
+        self.execute('kraken2-build', db, None, options={
+            '--threads':util.misc.sanitize_thread_count(num_threads),
+            '--download-taxonomy': None
+            })
+
+        # add standard libraries:
+        for lib in standard_libraries:
+            self.execute('kraken2-build', db, None, options={
+                '--threads':util.misc.sanitize_thread_count(num_threads),
+                '--download-library': lib
+                })
+        for lib in custom_libraries:
+            self.execute('kraken2-build', db, None, options={
+                '--threads':util.misc.sanitize_thread_count(num_threads),
+                '--add-to-library': lib
+                })
+
+        # build db
+        build_opts = {
+            '--build': None,
+            '--threads': util.misc.sanitize_thread_count(num_threads)
+        }
+        if k:
+            build_opts['--kmer-len'] = k
+        if l:
+            build_opts['--minimizer-len'] = l
+        if s:
+            build_opts['--minimizer-spaces'] = s
+        if protein:
+            build_opts['--protein'] = None
+        if max_db_size:
+            build_opts['--max-db-size'] = max_db_size
+        self.execute('kraken2-build', db, None, options=build_opts)
+
+        # grab the taxdump for krona!
+        if taxdump_out:
+            shutil.copyfile(os.path.join(db, 'taxonomy', 'taxdump.tar.gz'), taxdump_out)
+
+        # clean db
+        self.execute('kraken2-build', db, None, options=options={
+                '--threads':util.misc.sanitize_thread_count(num_threads),
+                '--clean': None
+                })
+
+    def inspect(self, db, output, num_threads=None):
+        with open(output, 'wt') as outf:
+            subprocess.check_call('kraken2-inspect',
+                '--db', db,
+                '--threads', util.misc.sanitize_thread_count(num_threads),
+                stdout=outf)
+
+    def execute(self, command, db, output, args=None, options=None):
+        '''Run a kraken-* command.
+
+        Args:
+          db: Kraken database directory.
+          output: Output file of command.
+          args: List of positional args.
+          options: List of keyword options.
+        '''
+        options = options or {}
+
+        if output:
+            options['--output'] = output
+        args = args or []
+
+        cmd = [command, '--db', db]
+        # We need some way to allow empty options args like --build, hence
+        # we filter out on 'x is None'.
+        cmd.extend([str(x) for x in itertools.chain(*options.items())
+                    if x is not None])
+        cmd.extend(args)
+        log.debug('Calling %s: %s', command, ' '.join(cmd))
+
+        subprocess.check_call(cmd)
+
+    def pipeline(self, db, in_bams, out_reports=None, out_reads=None,
+                 min_base_qual=None, num_threads=None):
+
+        assert out_reads is not None or out_reports is not None
+        out_reports = out_reports or []
+        out_reads = out_reads or []
+
+        for in_bam, out_read, out_report in itertools.zip_longest(in_bams, out_reads, out_reports):
+            self.classify(in_bam, db, out_reads=out_read, out_report=out_report,
+                min_base_qual=min_base_qual, confidence=confidence, num_threads=None)
+
+    def classify(self, in_bam, db, out_reads=None, out_report=None, confidence=None, min_base_qual=None, num_threads=None):
+        """Classify input reads (bam)
+
+        Args:
+          in_bam: unaligned reads
+          db: Kraken built database directory.
+          outReads: Output file of command.
+        """
+
+        if tools.samtools.SamtoolsTool().isEmpty(inBam):
+            # kraken cannot deal with empty input
+            if out_reads:
+                with open(out_reads, 'wt') as outf:
+                    pass
+            if out_report:
+                with open(out_report, 'wt') as outf:
+                    pass
+            return
+
+        opts = {
+            '--threads': util.misc.sanitize_thread_count(num_threads)
+        }
+        if out_report:
+            opts['--report'] = out_report
+        if not out_reads:
+            out_reads = '-' # in kraken2, this suppresses normal output
+        if min_base_qual:
+            opts['--minimum-base-quality'] = min_base_qual
+        if confidence:
+            opts['--confidence'] = confidence
+
+        tmp_fastq1 = util.file.mkstempfname('.1.fastq.gz')
+        tmp_fastq2 = util.file.mkstempfname('.2.fastq.gz')
+        tmp_fastq3 = util.file.mkstempfname('.s.fastq.gz')
+        # Do not convert this to samtools bam2fq unless we can figure out how to replicate
+        # the clipping functionality of Picard SamToFastq
+        picard = tools.picard.SamToFastqTool()
+        picard_opts = {
+            'CLIPPING_ATTRIBUTE': tools.picard.SamToFastqTool.illumina_clipping_attribute,
+            'CLIPPING_ACTION': 'X'
+        }
+        picard.execute(in_bam, tmp_fastq1, tmp_fastq2, outFastq0=tmp_fastq3,
+                       picardOptions=tools.picard.PicardTools.dict_to_picard_opts(picard_opts),
+                       JVMmemory=picard.jvmMemDefault)
+
+        if out_report:
+            opts['--report-file'] = out_report
+        # Detect if input bam was paired by checking fastq 2
+        if os.path.getsize(tmp_fastq2) < os.path.getsize(tmp_fastq3):
+            log.warn("running in single-end read mode!")
+            res = self.execute('kraken2', db, out_reads, args=[tmp_fastq3], options=opts)
+        else:
+            opts['--paired'] = None
+            res = self.execute('kraken2', db, out_reads, args=[tmp_fastq1, tmp_fastq2], options=opts)
+        os.unlink(tmp_fastq1)
+        os.unlink(tmp_fastq2)
+        os.unlink(tmp_fastq3)
+

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -186,7 +186,7 @@ class Kraken2(tools.Tool):
                        JVMmemory=picard.jvmMemDefault)
 
         if out_report:
-            opts['--report-file'] = out_report
+            opts['--report'] = out_report
         # Detect if input bam was paired by checking fastq 2
         if os.path.getsize(tmp_fastq2) < os.path.getsize(tmp_fastq3):
             log.warn("running in single-end read mode!")

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -129,7 +129,7 @@ class Kraken2(tools.Tool):
         subprocess.check_call(cmd)
 
     def pipeline(self, db, in_bams, out_reports=None, out_reads=None,
-                 min_base_qual=None, num_threads=None):
+                 min_base_qual=None, confidence=None, num_threads=None):
 
         assert out_reads is not None or out_reports is not None
         out_reports = out_reports or []
@@ -139,7 +139,8 @@ class Kraken2(tools.Tool):
             self.classify(in_bam, db, out_reads=out_read, out_report=out_report,
                 min_base_qual=min_base_qual, confidence=confidence, num_threads=None)
 
-    def classify(self, in_bam, db, out_reads=None, out_report=None, confidence=None, min_base_qual=None, num_threads=None):
+    def classify(self, in_bam, db, out_reads=None, out_report=None,
+                 confidence=None, min_base_qual=None, num_threads=None):
         """Classify input reads (bam)
 
         Args:

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -91,7 +91,7 @@ class Kraken2(tools.Tool):
             shutil.copyfile(os.path.join(db, 'taxonomy', 'taxdump.tar.gz'), taxdump_out)
 
         # clean db
-        self.execute('kraken2-build', db, None, options=options={
+        self.execute('kraken2-build', db, None, options={
                 '--threads':util.misc.sanitize_thread_count(num_threads),
                 '--clean': None
                 })

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -53,7 +53,8 @@ class Kraken2(tools.Tool):
         '''
 
         # all the library download and dustmasking can be *easily* parallelized
-        with concurrent.futures.ProcessPoolExecutor(max_workers=num_threads) as executor:
+        with concurrent.futures.ProcessPoolExecutor(
+            max_workers=util.misc.sanitize_thread_count(num_threads)) as executor:
 
             # use or fetch taxonomy database
             if tax_db:

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -146,10 +146,10 @@ class Kraken2(tools.Tool):
         Args:
           in_bam: unaligned reads
           db: Kraken built database directory.
-          outReads: Output file of command.
+          out_reads: Output file of command.
         """
 
-        if tools.samtools.SamtoolsTool().isEmpty(inBam):
+        if tools.samtools.SamtoolsTool().isEmpty(in_bam):
             # kraken cannot deal with empty input
             if out_reads:
                 with open(out_reads, 'wt') as outf:

--- a/classify/krona.py
+++ b/classify/krona.py
@@ -88,7 +88,7 @@ class Krona(tools.Tool):
 
         # get taxdump.tar.gz
         if taxdump_tar_gz:
-            shutil.copy(taxdump_tar_gz, db_dir)
+            shutil.copyfile(taxdump_tar_gz, os.path.join(db_dir, 'taxdump.tar.gz'))
         else:
             cmd = [os.path.join(self.opt, 'updateTaxonomy.sh'),
                 '--only-fetch', os.path.abspath(db_dir)]

--- a/classify/krona.py
+++ b/classify/krona.py
@@ -66,6 +66,8 @@ class Krona(tools.Tool):
 
     def create_db(self, db_dir):
         """Caution - this deletes the original .dmp files."""
+        if not self.executable_path():
+            self.install_and_get_path()
         bin_path = os.path.dirname(self.executable_path())
         env = os.environ.copy()
         env['PATH'] = '{}:{}'.format(bin_path, env['PATH'])
@@ -76,6 +78,8 @@ class Krona(tools.Tool):
 
     def build_db(self, db_dir, taxdump_tar_gz=None, get_accessions=False):
         """More all-in-one version of above"""
+        if not self.executable_path():
+            self.install_and_get_path()
         bin_path = os.path.dirname(self.executable_path())
         env = os.environ.copy()
         env['PATH'] = '{}:{}'.format(bin_path, env['PATH'])

--- a/classify/krona.py
+++ b/classify/krona.py
@@ -88,7 +88,7 @@ class Krona(tools.Tool):
 
         # get taxdump.tar.gz
         if taxdump_tar_gz:
-            shutil.copyfile(taxdump_tar_gz, db_dir)
+            shutil.copy(taxdump_tar_gz, db_dir)
         else:
             cmd = [os.path.join(self.opt, 'updateTaxonomy.sh'),
                 '--only-fetch', os.path.abspath(db_dir)]

--- a/classify/krona.py
+++ b/classify/krona.py
@@ -1,8 +1,9 @@
 import tools
 import os.path
 import subprocess
-from os.path import join
+import shutil
 from builtins import super
+import util.file
 
 TOOL_NAME = 'krona'
 CONDA_TOOL_VERSION = '2.7.1'
@@ -25,7 +26,7 @@ class Krona(tools.Tool):
             self.install_and_get_path()
         bin_path = os.path.dirname(self.executable_path())
         # Get at the opt directory from the conda env root
-        opt = os.path.abspath(join(bin_path, '..', 'opt', 'krona'))
+        opt = os.path.abspath(os.path.join(bin_path, '..', 'opt', 'krona'))
         return opt
 
     def import_taxonomy(self,
@@ -69,6 +70,39 @@ class Krona(tools.Tool):
         env = os.environ.copy()
         env['PATH'] = '{}:{}'.format(bin_path, env['PATH'])
 
-        sh = join(self.opt, 'updateTaxonomy.sh')
+        sh = os.path.join(self.opt, 'updateTaxonomy.sh')
         cmd = [sh, '--only-build', os.path.abspath(db_dir)]
         subprocess.check_call(cmd, env=env)
+
+    def build_db(self, db_dir, taxdump_tar_gz=None, get_accessions=False):
+        """More all-in-one version of above"""
+        bin_path = os.path.dirname(self.executable_path())
+        env = os.environ.copy()
+        env['PATH'] = '{}:{}'.format(bin_path, env['PATH'])
+
+        util.file.mkdir_p(db_dir)
+
+        # get taxdump.tar.gz
+        if taxdump_tar_gz:
+            shutil.copyfile(taxdump_tar_gz, db_dir)
+        else:
+            cmd = [os.path.join(self.opt, 'updateTaxonomy.sh'),
+                '--only-fetch', os.path.abspath(db_dir)]
+            subprocess.check_call(cmd, env=env)
+
+        # get accessions
+        if get_accessions:
+            cmd = [os.path.join(self.opt, 'updateAccessions.sh'),
+                '--only-fetch', os.path.abspath(db_dir)]
+            subprocess.check_call(cmd, env=env)
+
+        # build taxdb
+        cmd = [os.path.join(self.opt, 'updateTaxonomy.sh'),
+            '--only-build', os.path.abspath(db_dir)]
+        subprocess.check_call(cmd, env=env)
+
+        # build accessions
+        if get_accessions:
+            cmd = [os.path.join(self.opt, 'updateAccessions.sh'),
+                '--only-build', os.path.abspath(db_dir)]
+            subprocess.check_call(cmd, env=env)

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1396,7 +1396,7 @@ def parser_kraken2_build(parser=argparse.ArgumentParser()):
     parser.add_argument('--protein', action='store_true', help='Build protein database (default false/nucleotide).')
     parser.add_argument('--maxDbSize', type=int, help='Maximum db size in GB')
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
-    util.cmd.attach_main(parser, kraken_build, split_args=True)
+    util.cmd.attach_main(parser, kraken2_build, split_args=True)
     return parser
 def kraken2_build(db,
                 taxdump_out=None,
@@ -1421,7 +1421,7 @@ def kraken2_build(db,
         k=kmerLen, l=minimizerLen, s=minimizerSpaces,
         protein=protein,
         max_db_size=maxDbSize,
-        num_threads=threads):
+        num_threads=threads)
 
 __commands__.append(('kraken2_build', parser_kraken2_build))
 

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1391,6 +1391,7 @@ __commands__.append(('taxlevel_summary', parser_kraken_taxlevel_summary))
 
 def parser_kraken2_build(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Kraken database output directory.')
+    parser.add_argument('--tax_db', help='Use pre-existing kraken2 taxonomy db structure', default=None)
     parser.add_argument('--taxdump_out', help='Save ncbi taxdump.tar.gz file', default=None)
     parser.add_argument('--standard_libraries',
         nargs='+',
@@ -1409,7 +1410,7 @@ def parser_kraken2_build(parser=argparse.ArgumentParser()):
     util.cmd.attach_main(parser, kraken2_build, split_args=True)
     return parser
 def kraken2_build(db,
-                taxdump_out=None,
+                tax_db=None, taxdump_out=None,
                 standard_libraries=(), custom_libraries=(),
                 protein=False,
                 minimizerLen=None, kmerLen=None, minimizerSpaces=None,
@@ -1425,6 +1426,7 @@ def kraken2_build(db,
 
     kraken_tool = classify.kraken2.Kraken2()
     kraken_tool.build(db,
+        tax_db=tax_db,
         standard_libraries=standard_libraries,
         custom_libraries=custom_libraries,
         taxdump_out=taxdump_out,

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -733,7 +733,7 @@ def parser_kraken2(parser=argparse.ArgumentParser()):
         '--min_base_qual', default=0, type=int, help='Minimum base quality (default %(default)s)'
     )
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
-    util.cmd.attach_main(parser, kraken, split_args=True)
+    util.cmd.attach_main(parser, kraken2, split_args=True)
     return parser
 def kraken2(db, inBams, outReports=None, outReads=None, lockMemory=False, filterThreshold=None, threads=None):
     '''

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1392,13 +1392,19 @@ __commands__.append(('taxlevel_summary', parser_kraken_taxlevel_summary))
 def parser_kraken2_build(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Kraken database output directory.')
     parser.add_argument('--taxdump_out', help='Save ncbi taxdump.tar.gz file', default=None)
-    parser.add_argument('--standard_libraries', nargs='+', help='A list of "standard" kraken libraries to download on the fly and add.')
+    parser.add_argument('--standard_libraries',
+        nargs='+',
+        choices=["archaea", "bacteria", "plasmid",
+             "viral", "human", "fungi", "plant", "protozoa",
+             "nr", "nt", "env_nr", "env_nt", "UniVec",
+             "UniVec_Core"],
+        help='A list of "standard" kraken libraries to download on the fly and add.')
     parser.add_argument('--custom_libraries', nargs='+', help='Custom fasta files with properly formatted headers.')
-    parser.add_argument('--kmerLen', type=int, help='k-mer length (kraken2 default: 35nt/15aa)')
-    parser.add_argument('--minimizerLen', type=int, help='Minimizer length (kraken2 default: 31nt/12aa)')
-    parser.add_argument('--minimizerSpaces', type=int, help='Number of characters in minimizer that are ignored in comparisons (kraken2 default: 7nt/0aa)')
+    parser.add_argument('--kmerLen', type=int, help='(k) k-mer length (kraken2 default: 35nt/15aa)')
+    parser.add_argument('--minimizerLen', type=int, help='(l) Minimizer length (kraken2 default: 31nt/12aa)')
+    parser.add_argument('--minimizerSpaces', type=int, help='(s) Number of characters in minimizer that are ignored in comparisons (kraken2 default: 7nt/0aa)')
     parser.add_argument('--protein', action='store_true', help='Build protein database (default false/nucleotide).')
-    parser.add_argument('--maxDbSize', type=int, help='Maximum db size in GB')
+    parser.add_argument('--maxDbSize', type=int, help='Maximum db size in GB (default: none)')
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken2_build, split_args=True)
     return parser

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -739,7 +739,7 @@ def parser_kraken2(parser=argparse.ArgumentParser()):
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken2, split_args=True)
     return parser
-def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, confidence=confidence, threads=None):
+def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, confidence=None, threads=None):
     '''
         Classify reads by taxon using Kraken2
     '''

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -724,27 +724,26 @@ def kraken_dfs(db, lines, taxa_hits, total_hits, taxid, level):
         lines.append('\t'.join([percent_covered, str(cum_hits), str(num_hits), rank, str(taxid), '  ' * level + name]))
     return cum_hits
 
-def parser_kraken(parser=argparse.ArgumentParser()):
+def parser_kraken2(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Kraken database directory.')
     parser.add_argument('inBams', nargs='+', help='Input unaligned reads, BAM format.')
-    parser.add_argument('--outReports', nargs='+', help='Kraken summary report output file. Multiple filenames space separated.')
-    parser.add_argument('--outReads', nargs='+', help='Kraken per read classification output file. Multiple filenames space separated.')
-    parser.add_argument('--lockMemory', action='store_true', default=False, help='Lock kraken database in RAM. Requires high ulimit -l.')
+    parser.add_argument('--outReports', nargs='+', help='Kraken2 summary report output file. Multiple filenames space separated.')
+    parser.add_argument('--outReads', nargs='+', help='Kraken2 per read classification output file. Multiple filenames space separated.')
     parser.add_argument(
-        '--filterThreshold', default=0.05, type=float, help='Kraken filter threshold (default %(default)s)'
+        '--min_base_qual', default=0, type=int, help='Minimum base quality (default %(default)s)'
     )
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken, split_args=True)
     return parser
-def kraken(db, inBams, outReports=None, outReads=None, lockMemory=False, filterThreshold=None, threads=None):
+def kraken2(db, inBams, outReports=None, outReads=None, lockMemory=False, filterThreshold=None, threads=None):
     '''
-        Classify reads by taxon using Kraken
+        Classify reads by taxon using Kraken2
     '''
 
     assert outReads or outReports, ('Either --outReads or --outReport must be specified.')
-    kraken_tool = classify.kraken.Kraken()
-    kraken_tool.pipeline(db, inBams, outReports=outReports, outReads=outReads, lockMemory=lockMemory,
-                         filterThreshold=filterThreshold, num_threads=threads)
+    kraken_tool = classify.kraken.Kraken2()
+    kraken_tool.pipeline(db, inBams, outReports=outReports, outReads=outReads,
+                         min_base_qual=min_base_qual, num_threads=threads)
 __commands__.append(('kraken', parser_kraken))
 
 
@@ -772,7 +771,7 @@ __commands__.append(('krakenuniq', parser_krakenuniq))
 
 
 def parser_krona(parser=argparse.ArgumentParser()):
-    parser.add_argument('inReport', help='Input report file (default: tsv)')
+    parser.add_argument('inReports', nargs='+', help='Input report file (default: tsv)')
     parser.add_argument('db', help='Krona taxonomy database directory.')
     parser.add_argument('outHtml', help='Output html report.')
     parser.add_argument('--sample_name', help='Title of dataset (default basename(inReport))', default=None)
@@ -782,79 +781,99 @@ def parser_krona(parser=argparse.ArgumentParser()):
     parser.add_argument('--magnitudeColumn', help='Column of magnitude. (default %(default)s)', type=int, default=None)
     parser.add_argument('--noHits', help='Include wedge for no hits.', action='store_true')
     parser.add_argument('--noRank', help='Include no rank assignments.', action='store_true')
-    parser.add_argument('--inputType', help='Handling for specialized report types.', default='tsv', choices=['tsv', 'krakenuniq', 'kaiju'])
+    parser.add_argument('--inputType', help='Handling for specialized report types.', default='tsv', choices=['tsv', 'kraken2', 'krakenuniq', 'kaiju'])
     util.cmd.common_args(parser, (('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, krona, split_args=True)
     return parser
-def krona(inReport, db, outHtml, queryColumn=None, taxidColumn=None, scoreColumn=None, magnitudeColumn=None, noHits=None, noRank=None,
+def krona(inReports, db, outHtml, queryColumn=None, taxidColumn=None, scoreColumn=None, magnitudeColumn=None, noHits=None, noRank=None,
           inputType=None, sample_name=None):
     '''
         Create an interactive HTML report from a tabular metagenomic report
     '''
 
     krona_tool = classify.krona.Krona()
-    dataset_name = sample_name if (sample_name is not None) else os.path.basename(inReport)
+    if sample_name is not None:
+        dataset_names = list(sample_name for fn in inReports)
+    else:
+        dataset_names = list(os.path.basename(fn) for fn in inReports)
+
+    to_import = []
 
     with util.file.tempfname() as tmp_tsv:
-        with open(tmp_tsv, 'w') as f_out:
 
-            if inputType == 'tsv':
+    with util.file.tmp_dir() as tmp_dir:
+
+        if inputType == 'tsv':
+            for inReport in inReports:
                 if inReport.endswith('.gz'):
-                    tmp_tsv = util.file.mkstempfname('.tsv')
+                    tmp_tsv = util.file.mkstempfname('.tsv', directory=tmp_dir)
                     with gzip.open(inReport, 'rb') as f_in:
-                        shutil.copyfileobj(f_in, f_out)
-                        to_import = [tmp_tsv]
+                        with open(tmp_tsv, 'w') as f_out:
+                            shutil.copyfileobj(f_in, f_out)
+                            to_import.append(tmp_tsv)
                 else:
-                    to_import = [inReport]
+                    to_import.append(inReport)
 
-            elif inputType == 'krakenuniq':
-                queryColumn=None
-                taxidColumn=1
-                scoreColumn=3
-                magnitudeColumn=2
-                report = classify.kraken.KrakenUniq().read_report(inReport)
-                for taxid, (tax_reads, tax_kmers) in report.items():
-                    f_out.write('{}\t{}\t{}\n'.format(taxid, tax_reads, tax_kmers))
-                to_import = [tmp_tsv]
+        elif inputType == 'kraken2':
+            queryColumn=None
+            taxidColumn=5
+            scoreColumn=None
+            magnitudeColumn=3
+            to_import = inReports
 
-            elif inputType == 'kaiju':
-                queryColumn=None
-                taxidColumn=1
-                scoreColumn=None
-                magnitudeColumn=2
-                report = classify.kaiju.Kaiju().read_report(inReport)
-                for taxid, reads in report.items():
-                    f_out.write('{}\t{}\n'.format(taxid, reads))
-                to_import = [tmp_tsv]
+        elif inputType == 'krakenuniq':
+            queryColumn=None
+            taxidColumn=1
+            scoreColumn=3
+            magnitudeColumn=2
+            for inReport in inReports:
+                tmp_tsv = util.file.mkstempfname('.tsv', directory=tmp_dir)
+                with open(tmp_tsv, 'w') as f_out:
+                    report = classify.kraken.KrakenUniq().read_report(inReport)
+                    for taxid, (tax_reads, tax_kmers) in report.items():
+                        f_out.write('{}\t{}\t{}\n'.format(taxid, tax_reads, tax_kmers))
+                to_import.append(tmp_tsv)
 
-            else:
-                raise NotImplementedError
+        elif inputType == 'kaiju':
+            queryColumn=None
+            taxidColumn=1
+            scoreColumn=None
+            magnitudeColumn=2
+            for inReport in inReports:
+                tmp_tsv = util.file.mkstempfname('.tsv', directory=tmp_dir)
+                with open(tmp_tsv, 'w') as f_out:
+                    report = classify.kaiju.Kaiju().read_report(inReport)
+                    for taxid, reads in report.items():
+                        f_out.write('{}\t{}\n'.format(taxid, reads))
+                to_import.append(tmp_tsv)
 
-            # run krona
-            krona_tool.import_taxonomy(
-                db,
-                list(','.join((fn, dataset_name)) for fn in to_import),
-                outHtml,
-                query_column=queryColumn,
-                taxid_column=taxidColumn,
-                score_column=scoreColumn,
-                magnitude_column=magnitudeColumn,
-                no_hits=noHits,
-                no_rank=noRank
-            )
+        else:
+            raise NotImplementedError
 
-        os.unlink(tmp_tsv)
+        # run krona
+        krona_tool.import_taxonomy(
+            db,
+            list(','.join(pair) for pair in zip(to_import, dataset_names)),
+            outHtml,
+            query_column=queryColumn,
+            taxid_column=taxidColumn,
+            score_column=scoreColumn,
+            magnitude_column=magnitudeColumn,
+            no_hits=noHits,
+            no_rank=noRank
+        )
+
 
         if inputType == 'krakenuniq':
             # Rename "Avg. score" to "Est. genome coverage"
             html_lines = util.file.slurp_file(outHtml).split('\n')
+            tmp_tsv = util.file.mkstempfname('.tsv', directory=tmp_dir)
             with open(tmp_tsv, 'w') as new_report:
                 for line in html_lines:
                     if '<attribute display="Avg. score">score</attribute>' in line:
                         line = line.replace('Avg. score', 'Est. unique kmers')
                     print(line, file=new_report)
             shutil.copyfile(tmp_tsv, outHtml)
-            os.unlink(tmp_tsv)
 
 __commands__.append(('krona', parser_krona))
 
@@ -1370,109 +1389,41 @@ def taxlevel_summary(summary_files_in, json_out, csv_out, tax_headings, taxlevel
 __commands__.append(('taxlevel_summary', parser_kraken_taxlevel_summary))
 
 
-def parser_kraken_build(parser=argparse.ArgumentParser()):
+def parser_kraken2_build(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Kraken database output directory.')
     parser.add_argument('--library', help='Input library directory of fasta files. If not specified, it will be read from the "library" subdirectory of "db".')
-    parser.add_argument('--taxonomy', help='Taxonomy db directory. If not specified, it will be read from the "taxonomy" subdirectory of "db".')
-    parser.add_argument('--subsetTaxonomy', action='store_true', help='Subset taxonomy based on library fastas.')
-    parser.add_argument('--minimizerLen', type=int, help='Minimizer length (kraken default: 15)')
-    parser.add_argument('--kmerLen', type=int, help='k-mer length (kraken default: 31)')
-    parser.add_argument('--maxDbSize', type=int, help='Maximum db size in GB (will shrink if too big)')
-    parser.add_argument('--clean', action='store_true', help='Clean by deleting other database files after build')
-    parser.add_argument('--workOnDisk', action='store_true', help='Work on disk instead of RAM. This is generally much slower unless the "db" directory lives on a RAM disk.')
+    parser.add_argument('--kmerLen', type=int, help='k-mer length (kraken2 default: 35nt/15aa)')
+    parser.add_argument('--minimizerLen', type=int, help='Minimizer length (kraken2 default: 31nt/12aa)')
+    parser.add_argument('--minimizerSpaces', type=int, help='Number of characters in minimizer that are ignored in comparisons (kraken2 default: 7nt/0aa)')
+    parser.add_argument('--protein', action='store_true', help='Build protein database (default false/nucleotide).')
+    parser.add_argument('--maxDbSize', type=int, help='Maximum db size in GB')
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken_build, split_args=True)
     return parser
-def kraken_build(db, library, taxonomy=None, subsetTaxonomy=None,
-                threads=None, workOnDisk=False,
-                minimizerLen=None, kmerLen=None, maxDbSize=None, clean=False):
+def kraken2_build(db, library,
+                protein=False,
+                minimizerLen=None, kmerLen=None, minimizerSpaces=None,
+                maxDbSize=None, threads=None):
     '''
-    Builds a kraken database from library directory of fastas and taxonomy db
+    Builds a kraken2 database from library directory of fastas and taxonomy db
     directory. The --subsetTaxonomy option allows shrinking the taxonomy to only
     include taxids associated with the library folders. For this to work, the
     library fastas must have the standard id names such as `>NC1234.1`
     accessions, `>gi|123456789|ref|XXXX||`, or custom kraken name
     `>kraken:taxid|1234|`.
-
-    Setting the --minimizerLen (default: 16) small, such as 10, will drastically
-    shrink the db size for small inputs, which is useful for testing.
-
-    The built db may include symlinks to the original --library / --taxonomy
-    directories. If you want to build a static archiveable version of the
-    library, simply use the --clean option, which will also remove any
-    unnecessary files.
     '''
-    util.file.mkdir_p(db)
-    library_dir = os.path.join(db, 'library')
-    library_exists = os.path.exists(library_dir)
-    if library:
-        try:
-            os.symlink(os.path.abspath(library), os.path.join(db, 'library'))
-        except FileExistsError:
-            pass
-    else:
-        if not library_exists:
-            raise FileNotFoundError('Library directory {} not found'.format(library_dir))
 
-    taxonomy_dir = os.path.join(db, 'taxonomy')
-    taxonomy_exists = os.path.exists(taxonomy_dir)
-    if taxonomy:
-        if taxonomy_exists:
-            raise KrakenBuildError('Output db directory already contains taxonomy directory {}'.format(taxonomy_dir))
-        if subsetTaxonomy:
-            kraken_taxids, kraken_gis, kraken_accessions = kraken_library_ids(library)
+    kraken_tool = classify.kraken.Kraken2()
+    kraken_tool.build(db,
+        standard_libraries=standard_libraries,
+        custom_libraries=custom_libraries,
+        taxdump_out=taxdump_out,
+        k=kmerLen, l=minimizerLen, s=minimizerSpaces,
+        protein=protein,
+        max_db_size=maxDbSize,
+        num_threads=threads):
 
-            whitelist_taxid_f = util.file.mkstempfname()
-            with open(whitelist_taxid_f, 'wt') as f:
-                for taxid in kraken_taxids:
-                    print(taxid, file=f)
-
-            whitelist_gi_f = util.file.mkstempfname()
-            with open(whitelist_gi_f, 'wt') as f:
-                for gi in kraken_gis:
-                    print(gi, file=f)
-
-            whitelist_accession_f = util.file.mkstempfname()
-            with open(whitelist_accession_f, 'wt') as f:
-                for accession in kraken_accessions:
-                    print(accession, file=f)
-
-            # Context-managerize eventually
-            taxonomy_tmp = tempfile.mkdtemp()
-            subset_taxonomy(taxonomy, taxonomy_tmp, whitelistTaxidFile=whitelist_taxid_f,
-                            whitelistGiFile=whitelist_gi_f, whitelistAccessionFile=whitelist_accession_f)
-            shutil.move(taxonomy_tmp, taxonomy_dir)
-        else:
-            os.symlink(os.path.abspath(taxonomy), taxonomy_dir)
-        for fn in os.listdir(os.path.join(taxonomy_dir, 'accession2taxid')):
-            if not fn.endswith('accession2taxid'):
-                continue
-
-            os.symlink(os.path.join(taxonomy_dir, 'accession2taxid', fn),
-                       os.path.join(taxonomy_dir, fn))
-    else:
-        if not taxonomy_exists:
-            raise FileNotFoundError('Taxonomy directory {} not found'.format(taxonomy_dir))
-        if subsetTaxonomy:
-            raise KrakenBuildError('Cannot subset taxonomy if already in db folder')
-
-    kraken_tool = classify.kraken.Kraken()
-    options = {'--build': None}
-    if threads:
-        options['--threads'] = threads
-    if minimizerLen:
-        options['--minimizer-len'] = minimizerLen
-    if kmerLen:
-        options['--kmer-len'] = kmerLen
-    if maxDbSize:
-        options['--max-db-size'] = maxDbSize
-    if workOnDisk:
-        options['--work-on-disk'] = None
-    kraken_tool.build(db, options=options)
-
-    if clean:
-        kraken_tool.execute('kraken-build', db, '', options={'--clean': None})
-__commands__.append(('kraken_build', parser_kraken_build))
+__commands__.append(('kraken2_build', parser_kraken2_build))
 
 
 def parser_krakenuniq_build(parser=argparse.ArgumentParser()):

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -797,11 +797,8 @@ def krona(inReports, db, outHtml, queryColumn=None, taxidColumn=None, scoreColum
     else:
         dataset_names = list(os.path.basename(fn) for fn in inReports)
 
-    to_import = []
-
-    with util.file.tempfname() as tmp_tsv:
-
     with util.file.tmp_dir() as tmp_dir:
+        to_import = []
 
         if inputType == 'tsv':
             for inReport in inReports:
@@ -862,7 +859,6 @@ def krona(inReports, db, outHtml, queryColumn=None, taxidColumn=None, scoreColum
             no_hits=noHits,
             no_rank=noRank
         )
-
 
         if inputType == 'krakenuniq':
             # Rename "Avg. score" to "Est. genome coverage"

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -35,6 +35,7 @@ import tools.samtools
 
 import classify.kaiju
 import classify.kraken
+import classify.kraken2
 import classify.krona
 
 __commands__ = []
@@ -741,7 +742,7 @@ def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, thre
     '''
 
     assert outReads or outReports, ('Either --outReads or --outReport must be specified.')
-    kraken_tool = classify.kraken.Kraken2()
+    kraken_tool = classify.kraken2.Kraken2()
     kraken_tool.pipeline(db, inBams, outReports=outReports, outReads=outReads,
                          min_base_qual=min_base_qual, num_threads=threads)
 __commands__.append(('kraken2', parser_kraken2))
@@ -1413,7 +1414,7 @@ def kraken2_build(db,
     `>kraken:taxid|1234|`.
     '''
 
-    kraken_tool = classify.kraken.Kraken2()
+    kraken_tool = classify.kraken2.Kraken2()
     kraken_tool.build(db,
         standard_libraries=standard_libraries,
         custom_libraries=custom_libraries,

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -744,7 +744,7 @@ def kraken2(db, inBams, outReports=None, outReads=None, lockMemory=False, filter
     kraken_tool = classify.kraken.Kraken2()
     kraken_tool.pipeline(db, inBams, outReports=outReports, outReads=outReads,
                          min_base_qual=min_base_qual, num_threads=threads)
-__commands__.append(('kraken', parser_kraken))
+__commands__.append(('kraken', parser_kraken2))
 
 
 def parser_krakenuniq(parser=argparse.ArgumentParser()):

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -735,7 +735,7 @@ def parser_kraken2(parser=argparse.ArgumentParser()):
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken2, split_args=True)
     return parser
-def kraken2(db, inBams, outReports=None, outReads=None, lockMemory=False, filterThreshold=None, threads=None):
+def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, threads=None):
     '''
         Classify reads by taxon using Kraken2
     '''
@@ -744,7 +744,7 @@ def kraken2(db, inBams, outReports=None, outReads=None, lockMemory=False, filter
     kraken_tool = classify.kraken.Kraken2()
     kraken_tool.pipeline(db, inBams, outReports=outReports, outReads=outReads,
                          min_base_qual=min_base_qual, num_threads=threads)
-__commands__.append(('kraken', parser_kraken2))
+__commands__.append(('kraken2', parser_kraken2))
 
 
 def parser_krakenuniq(parser=argparse.ArgumentParser()):

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1391,7 +1391,9 @@ __commands__.append(('taxlevel_summary', parser_kraken_taxlevel_summary))
 
 def parser_kraken2_build(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Kraken database output directory.')
-    parser.add_argument('--library', help='Input library directory of fasta files. If not specified, it will be read from the "library" subdirectory of "db".')
+    parser.add_argument('--taxdump_out', help='Save ncbi taxdump.tar.gz file', default=None)
+    parser.add_argument('--standard_libraries', nargs='+', help='A list of "standard" kraken libraries to download on the fly and add.')
+    parser.add_argument('--custom_libraries', nargs='+', help='Custom fasta files with properly formatted headers.')
     parser.add_argument('--kmerLen', type=int, help='k-mer length (kraken2 default: 35nt/15aa)')
     parser.add_argument('--minimizerLen', type=int, help='Minimizer length (kraken2 default: 31nt/12aa)')
     parser.add_argument('--minimizerSpaces', type=int, help='Number of characters in minimizer that are ignored in comparisons (kraken2 default: 7nt/0aa)')
@@ -1400,7 +1402,9 @@ def parser_kraken2_build(parser=argparse.ArgumentParser()):
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken_build, split_args=True)
     return parser
-def kraken2_build(db, library,
+def kraken2_build(db,
+                taxdump_out=None,
+                standard_libraries=(), custom_libraries=(),
                 protein=False,
                 minimizerLen=None, kmerLen=None, minimizerSpaces=None,
                 maxDbSize=None, threads=None):

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -733,18 +733,21 @@ def parser_kraken2(parser=argparse.ArgumentParser()):
     parser.add_argument(
         '--min_base_qual', default=0, type=int, help='Minimum base quality (default %(default)s)'
     )
+    parser.add_argument(
+        '--confidence', default=0.0, type=float, help='Kraken2 confidence score threshold (default %(default)s)'
+    )
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken2, split_args=True)
     return parser
-def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, threads=None):
+def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, confidence=confidence, threads=None):
     '''
         Classify reads by taxon using Kraken2
     '''
 
     assert outReads or outReports, ('Either --outReads or --outReport must be specified.')
     kraken_tool = classify.kraken2.Kraken2()
-    kraken_tool.pipeline(db, inBams, outReports=outReports, outReads=outReads,
-                         min_base_qual=min_base_qual, num_threads=threads)
+    kraken_tool.pipeline(db, inBams, out_reports=outReports, out_reads=outReads,
+                         min_base_qual=min_base_qual, confidence=confidence, num_threads=threads)
 __commands__.append(('kraken2', parser_kraken2))
 
 

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1389,6 +1389,22 @@ def taxlevel_summary(summary_files_in, json_out, csv_out, tax_headings, taxlevel
 __commands__.append(('taxlevel_summary', parser_kraken_taxlevel_summary))
 
 
+def parser_krona_build(parser=argparse.ArgumentParser()):
+    parser.add_argument('db', help='Krona taxonomy database output directory.')
+    parser.add_argument('--taxdump_tar_gz', help='NCBI taxdump.tar.gz file', default=None)
+    parser.add_argument('--get_accessions', action='store_true', help='Fetch NCBI accession to taxid mappings. This is not required for processing kraken1/2/uniq hits, only for BLAST hits, and adds a significant amount of time and database space (default false).')
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
+    util.cmd.attach_main(parser, krona_build, split_args=True)
+    return parser
+def krona_build(db, taxdump_tar_gz=None, get_accessions=False):
+    '''
+    Builds a Krona taxonomy database
+    '''
+    classify.krona.Krona().build_db(
+        db, taxdump_tar_gz=taxdump_tar_gz, get_accessions=get_accessions)
+__commands__.append(('krona_build', parser_krona_build))
+
+
 def parser_kraken2_build(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Kraken database output directory.')
     parser.add_argument('--tax_db', help='Use pre-existing kraken2 taxonomy db structure', default=None)

--- a/requirements-conda-env2.txt
+++ b/requirements-conda-env2.txt
@@ -1,0 +1,3 @@
+krakenuniq=0.5.7_yesimon
+diamond=0.9.10
+kaiju=1.6.3_yesimon

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -4,5 +4,6 @@ diamond=0.9.10
 kmc=3.1.1rc1
 kaiju=1.6.3_yesimon
 krakenuniq=0.5.7_yesimon
-krona=2.7.1
+kraken2>=2.0.8_beta
+krona>=2.7.1
 last=876

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,9 +1,6 @@
 blast=2.7.1
 bmtagger=3.101
-diamond=0.9.10
 kmc=3.1.1rc1
-kaiju=1.6.3_yesimon
-krakenuniq=0.5.7_yesimon
 kraken2>=2.0.8_beta
 krona>=2.7.1
 last=876

--- a/test/unit/test_metagenomics.py
+++ b/test/unit/test_metagenomics.py
@@ -47,7 +47,7 @@ class TestKronaCalls(TestCaseWithTmp):
 
     def test_krona_import_taxonomy(self):
         out_html = util.file.mkstempfname('.html')
-        metagenomics.krona(self.inTsv, self.db, out_html, queryColumn=3, taxidColumn=5, scoreColumn=7,
+        metagenomics.krona([self.inTsv], self.db, out_html, queryColumn=3, taxidColumn=5, scoreColumn=7,
                            noHits=True, noRank=True, inputType='tsv')
         self.mock_krona().import_taxonomy.assert_called_once_with(
             self.db, [self.inTsv + ',' + os.path.basename(self.inTsv)], out_html, query_column=3, taxid_column=5, score_column=7,


### PR DESCRIPTION
Adds kraken2 to viral-classify
- adds classify.kraken2 class
- adds metagenomics.kraken2, metagenomics.kraken2_build commands
- adds "kraken2" inputType option to metagenomics.krona
- adds a metagenomics.krona_build option that creates a krona taxonomy db (either with a fresh NCBI pull or with provided taxdump.tar.gz as input)
- separates kraken2 and krakenuniq to two different conda environments, since they cannot coexist in the same conda environment (they write the same binaries to various parts of the path). I've manually verified that both tools still work from the top level either way
- removed some kraken1 (non-uniq) code from metagenomics.py since it wasn't working anyway (though it could possibly be revived by making a third conda environment -- it has the same incompatibility issues that k2 & kuniq have.