### PR TITLE
filter bam from taxa

### DIFF
--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -134,7 +134,7 @@ class Kraken2(tools.Tool):
         subprocess.check_call(cmd)
 
     def pipeline(self, db, in_bams, out_reports=None, out_reads=None,
-                 min_base_qual=None, confidence=None, num_threads=None):
+                 min_base_qual=None, confidence=None, minimum_hit_groups=None, num_threads=None):
 
         assert out_reads is not None or out_reports is not None
         out_reports = out_reports or []
@@ -142,10 +142,11 @@ class Kraken2(tools.Tool):
 
         for in_bam, out_read, out_report in itertools.zip_longest(in_bams, out_reads, out_reports):
             self.classify(in_bam, db, out_reads=out_read, out_report=out_report,
-                min_base_qual=min_base_qual, confidence=confidence, num_threads=None)
+                min_base_qual=min_base_qual, confidence=confidence,
+                minimum_hit_groups=minimum_hit_groups, num_threads=None)
 
     def classify(self, in_bam, db, out_reads=None, out_report=None,
-                 confidence=None, min_base_qual=None, num_threads=None):
+                 confidence=None, min_base_qual=None, minimum_hit_groups=None, num_threads=None):
         """Classify input reads (bam)
 
         Args:
@@ -175,6 +176,8 @@ class Kraken2(tools.Tool):
             opts['--minimum-base-quality'] = min_base_qual
         if confidence:
             opts['--confidence'] = confidence
+        if minimum_hit_groups:
+            opts['--minimum-hit-groups'] = minimum_hit_groups
 
         tmp_fastq1 = util.file.mkstempfname('.1.fastq')
         tmp_fastq2 = util.file.mkstempfname('.2.fastq')

--- a/classify/kraken2.py
+++ b/classify/kraken2.py
@@ -176,9 +176,9 @@ class Kraken2(tools.Tool):
         if confidence:
             opts['--confidence'] = confidence
 
-        tmp_fastq1 = util.file.mkstempfname('.1.fastq.gz')
-        tmp_fastq2 = util.file.mkstempfname('.2.fastq.gz')
-        tmp_fastq3 = util.file.mkstempfname('.s.fastq.gz')
+        tmp_fastq1 = util.file.mkstempfname('.1.fastq')
+        tmp_fastq2 = util.file.mkstempfname('.2.fastq')
+        tmp_fastq3 = util.file.mkstempfname('.s.fastq')
         # Do not convert this to samtools bam2fq unless we can figure out how to replicate
         # the clipping functionality of Picard SamToFastq
         picard = tools.picard.SamToFastqTool()

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1087,7 +1087,7 @@ def filter_bam_to_taxa(in_bam, read_IDs_to_tax_IDs, out_bam,
             tax_ids_to_include |= set(child_ids)
 
     tax_ids_to_include = frozenset(tax_ids_to_include) # frozenset membership check slightly faster
-    log_info("matching against {} taxa".format(len(tax_ids_to_include)))
+    log.info("matching against {} taxa".format(len(tax_ids_to_include)))
 
     # perform the actual filtering to return a list of read IDs, writeen to a temp file
     with util.file.tempfname(".txt.gz") as temp_read_list:

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1087,6 +1087,7 @@ def filter_bam_to_taxa(in_bam, read_IDs_to_tax_IDs, out_bam,
             tax_ids_to_include |= set(child_ids)
 
     tax_ids_to_include = frozenset(tax_ids_to_include) # frozenset membership check slightly faster
+    log_info("matching against {} taxa".format(len(tax_ids_to_include)))
 
     # perform the actual filtering to return a list of read IDs, writeen to a temp file
     with util.file.tempfname(".txt.gz") as temp_read_list:
@@ -1102,9 +1103,9 @@ def filter_bam_to_taxa(in_bam, read_IDs_to_tax_IDs, out_bam,
                 read_id_match = re.match(paired_read_base_pattern,read_id)
                 if (read_id_match and
                     read_tax_id in tax_ids_to_include):
-                    log.debug("Found matching read ID: %s", read_id_match.group(1))
                     read_IDs_file.write(read_id_match.group(1)+"\n")
                     read_ids_written+=1
+        log.info("matched {} reads".format(read_ids_written))
 
         # report count if desired
         if out_count:

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -731,15 +731,18 @@ def parser_kraken2(parser=argparse.ArgumentParser()):
     parser.add_argument('--outReports', nargs='+', help='Kraken2 summary report output file. Multiple filenames space separated.')
     parser.add_argument('--outReads', nargs='+', help='Kraken2 per read classification output file. Multiple filenames space separated.')
     parser.add_argument(
-        '--min_base_qual', default=0, type=int, help='Minimum base quality (default %(default)s)'
+        '--minimum_hit_groups', default=None, type=int, help='Minimum hit groups (Kraken2 default: 2)'
     )
     parser.add_argument(
-        '--confidence', default=0.0, type=float, help='Kraken2 confidence score threshold (default %(default)s)'
+        '--min_base_qual', default=None, type=int, help='Minimum base quality (default %(default)s)'
+    )
+    parser.add_argument(
+        '--confidence', default=None, type=float, help='Kraken2 confidence score threshold (default %(default)s)'
     )
     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, kraken2, split_args=True)
     return parser
-def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, confidence=None, threads=None):
+def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, confidence=None, minimum_hit_groups=None, threads=None):
     '''
         Classify reads by taxon using Kraken2
     '''
@@ -747,7 +750,8 @@ def kraken2(db, inBams, outReports=None, outReads=None, min_base_qual=None, conf
     assert outReads or outReports, ('Either --outReads or --outReport must be specified.')
     kraken_tool = classify.kraken2.Kraken2()
     kraken_tool.pipeline(db, inBams, out_reports=outReports, out_reads=outReads,
-                         min_base_qual=min_base_qual, confidence=confidence, num_threads=threads)
+                         min_base_qual=min_base_qual, confidence=confidence,
+                         minimum_hit_groups=minimum_hit_groups, num_threads=threads)
 __commands__.append(('kraken2', parser_kraken2))
 
 

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,6 +1,6 @@
 blast=2.7.1
 bmtagger=3.101
 kmc=3.1.1rc1
-kraken2>=2.0.8_beta
+kraken2>=2.0.9_beta
 krona>=2.7.1
 last=876

--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,6 +1,6 @@
 blast=2.7.1
 bmtagger=3.101
 kmc=3.1.1rc1
-kraken2>=2.0.9_beta
+kraken2>=2.0.9beta
 krona>=2.7.1
 last=876


### PR DESCRIPTION
1. adds an `--exclude` option to filter_bam_to_taxa to make it work in the opposite direction
2. changes the picard samtofastq prior to kraken2 to dump to an uncompressed fastq (no gz) for speed's sake