### PR TITLE
add metagenomics.taxlevel_plurality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
   release:
     types:
       - created
-  schedule:
-    - cron: '0 18 * * 1' # weekly at 18:00 on Mondays
 
 env:
   HOME: "${{ github.workspace }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # fetch git tags (tagged releases) because
-      # actions/checkout@v3 does either a full checkout or a shallow checkout without tags
+      # actions/checkout@v4 does either a full checkout or a shallow checkout without tags
       - name: fetch tags
         run: git fetch --prune --unshallow --tags
       - name: Programmatic environment setup
@@ -74,7 +74,7 @@ jobs:
           echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH" >> $GITHUB_ENV
 
       - name: Login to docker registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -82,7 +82,7 @@ jobs:
       # cache; see: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
       - name: setup cache
         id: docker_cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: old-docker-tag
         with:
@@ -201,9 +201,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # fetch git tags (tagged releases) because 
-      # actions/checkout@v3 does either a full checkout or a shallow checkout without tags
+      # actions/checkout@v4 does either a full checkout or a shallow checkout without tags
       - name: fetch tags
         run: git fetch --prune --unshallow --tags
       - name: Programmatic environment setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: "viral-classify CI"
 
 on:
   push:
+  merge_group:
   pull_request:
     branches:
       - master

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
@@ -19,6 +25,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.10
   install:
     - requirements: docs/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.2.3
+FROM quay.io/broadinstitute/viral-core:2.2.4
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -726,7 +726,7 @@ def filter_taxids_to_focal_hits(taxids_tsv, focal_report_tsv, taxdb_dir, min_rea
     # load focal hits
     hits = set()
     with util.file.open_or_gzopen(focal_report_tsv, "rt") as inf:
-        for row in csv.reader(inf, delimiter='\t'):
+        for row in csv.DictReader(inf, delimiter='\t'):
             if int(row['reads_excl_children']) >= min_read_count:
                 hits.add(row['taxon_id'])
 

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1462,7 +1462,7 @@ def taxlevel_plurality(summary_file, tax_heading, out_report):
             row = next(csv.DictReader([line.strip().rstrip('\n')], fieldnames=fieldnames, dialect="kraken_report"))
 
             try:
-                indent_of_line = indent_len(row["sci_name"])
+                indent_of_line = indent_len(row["taxon_sci_name"])
             except AttributeError as e:
                 log.warning("Report type: '{}'".format(report_type))
                 log.warning("Issue with line {}: '{}'".format(lineno,line.strip().rstrip('\n')))
@@ -1475,7 +1475,7 @@ def taxlevel_plurality(summary_file, tax_heading, out_report):
                 indent_of_selection=-1
 
             if indent_of_selection == -1:
-                if row["sci_name"].lower() == tax_heading.lower():
+                if row["taxon_sci_name"].lower() == tax_heading.lower():
                     should_process = True
                     indent_of_selection = indent_of_line
 
@@ -1489,10 +1489,10 @@ def taxlevel_plurality(summary_file, tax_heading, out_report):
         out.append({'order_within_focal':0, 'focal_taxon_name':tax_heading, 'focal_taxon_count':0, 'pct_of_focal':0.0, 'pct_of_total':0.0, 'reads_cumulative':0, 'reads_excl_children':0, 'taxon_rank':'', 'taxon_id':'', 'taxon_sci_name':''})
     else:
         # find the most abundant taxon classified underneath (but not including) the tax_heading 
-        assert keeper_rows[0]["sci_name"].lower() == tax_heading.lower()
+        assert keeper_rows[0]["taxon_sci_name"].lower() == tax_heading.lower()
         keepers_sorted = enumerate(sorted(keeper_rows[1:], key=lambda row:int(row["reads_excl_children"]), reverse=True))
         for i, hit in keepers_sorted:
-            outrow = {'order_within_focal': i+1, 'focal_taxon_name':keeper_rows[0]["sci_name"], 'focal_taxon_count':keeper_rows[0]["reads_cumulative"], 'pct_of_focal': float(row["reads_excl_children"]) / float(keeper_rows[0]["reads_cumulative"])}
+            outrow = {'order_within_focal': i+1, 'focal_taxon_name':keeper_rows[0]["taxon_sci_name"], 'focal_taxon_count':keeper_rows[0]["reads_cumulative"], 'pct_of_focal': float(row["reads_excl_children"]) / float(keeper_rows[0]["reads_cumulative"])}
             for k in ("pct_of_total", "reads_cumulative", "reads_excl_children", "taxon_rank", "taxon_id", "taxon_sci_name"):
                 outrow[k] = hit[k]
             out.append(outrow)

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -300,7 +300,7 @@ class TaxonomyDb(object):
         '''Recursively do DFS for number of hits per taxa.'''
         cum_hits = num_hits = taxa_hits.get(taxid, 0)
         for child_taxid in self.children[taxid]:
-            cum_hits += kraken_dfs(db, lines, taxa_hits, total_hits, child_taxid, level + 1)
+            cum_hits += self.kraken_dfs(lines, taxa_hits, total_hits, child_taxid, level + 1)
         percent_covered = '%.2f' % (cum_hits / total_hits * 100)
         rank = rank_code(self.ranks[taxid])
         name = self.names[taxid]

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1404,6 +1404,263 @@ def taxlevel_summary(summary_files_in, json_out, csv_out, tax_headings, taxlevel
 __commands__.append(('taxlevel_summary', parser_kraken_taxlevel_summary))
 
 
+def parser_kraken_taxlevel_plurality(parser=argparse.ArgumentParser()):
+    parser.add_argument('summary_file', help='input Kraken-format summary text file with tab-delimited taxonomic levels.')
+    parser.add_argument('tax_heading', help='The taxonomic heading to analyze.')
+    parser.add_argument('out_report', help='tab-delimited output file.')
+    util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
+    util.cmd.attach_main(parser, taxlevel_summary, split_args=True)
+    return parser
+
+def taxlevel_plurality(summary_file, tax_heading, out_report):
+    """
+        Identifies the most abundant taxon (of any rank) contributing to a node of interest in the taxonomic tree.
+        It is intended to highlight the primary contributor of taxonomic signal within a taxonomic category of interest,
+        for example, the most abundant virus among all viruses.
+    """
+
+    samples = {}
+    same_level = False
+
+    Abundance = collections.namedtuple("Abundance", "percent,count,kmers,dup,cov")
+
+    def indent_len(in_string):
+        return len(in_string)-len(in_string.lstrip())
+
+    for f in list(summary_files_in):
+        sample_name, extension = os.path.splitext(f)
+        sample_summary = {}
+        sample_root_summary = {}
+        tax_headings_copy = [s.lower() for s in tax_headings]
+
+        # -----------------------------------------------------------------
+        # KrakenUniq has two lines prefixed by '#', a blank line,
+        # and then a TSV header beginning with "%". The column fields are:
+        # (NB:field names accurate, but space-separated in this comment 
+        # for readability here)
+        #   %        reads  taxReads  kmers  dup   cov  taxID  rank          taxName
+        #   0.05591  2      0         13     1.85  NA   10239  superkingdom  Viruses
+        #
+        # Where the fields are:
+        #   %:
+        #   reads:
+        #   taxReads:
+        #   kmers: number of unique k-mers
+        #   dup: average number of times each unique k-mer has been seen
+        #   cov: coverage of the k-mers of the clade in the database
+        #   taxID: 
+        #   rank: row["rank"]; A rank code (see list below)
+        #   taxName: row["sci_name"]; indented scientific name
+        #
+        # Taxonomic ranks used by KrakenUniq include:
+        #   unknown, no rank, sequence, assembly, subspecies, 
+        #   species, species subgroup, species group, subgenus, 
+        #   genus, tribe, subfamily, family, superfamily, parvorder, 
+        #   infraorder, suborder, order, superorder, parvclass, 
+        #   infraclass, subclass, class, superclass, subphylum, 
+        #   phylum, kingdom, superkingdom, root
+        #
+        #   via: https://github.com/fbreitwieser/krakenuniq/blob/a8b4a2dbf50553e02d3cab3c32f93f91958aa575/src/taxdb.hpp#L96-L131
+        # -----------------------------------------------------------------
+        # Kraken (standard) reports lack header lines. 
+        # (NB:field names below are only for reference. Space-separated for 
+        # readability here)
+        #   %     reads  taxReads  rank  taxID      taxName
+        #   0.00  16     0         D     10239      Viruses
+        #
+        # Where the fields are:
+        #   %:        row["pct_of_reads"]; Percentage of reads covered by the clade rooted at this taxon
+        #   reads:    row["num_reads"]; Number of reads covered by the clade rooted at this taxon
+        #   taxReads: row["reads_exc_children"]; Number of reads assigned directly to this taxon
+        #   rank:     row["rank"]; A rank code, indicating (U)nclassified, (D)omain, (K)ingdom, (P)hylum, (C)lass, (O)rder, (F)amily, (G)enus, or (S)pecies. All other ranks are simply '-'.
+        #   taxID:    row["NCBI_tax_ID"]; NCBI taxonomy ID
+        #   taxName:  row["sci_name"]; indented scientific name
+        # -----------------------------------------------------------------
+
+
+        with util.file.open_or_gzopen(f, 'rt') as inf:
+            report_type=None
+            should_process = False
+            indent_of_selection = -1
+            currently_being_processed = ""
+            for lineno, line in enumerate(inf):
+                if len(line.rstrip('\r\n').strip()) == 0 or ( report_type != None and line.startswith("#") or line.startswith("%")):
+                    continue
+
+                # KrakenUniq is mentioned on the first line of
+                # summary reports created by KrakenUniq
+                if not report_type and "KrakenUniq" in line:
+                    report_type="krakenuniq"
+                    continue
+                elif not report_type:
+                    report_type="kraken"                
+
+                csv.register_dialect('kraken_report', quoting=csv.QUOTE_MINIMAL, delimiter="\t")
+                if report_type == "kraken":
+                    fieldnames = [ "pct_of_reads",
+                                    "num_reads",
+                                    "reads_exc_children",
+                                    "rank",
+                                    "NCBI_tax_ID",
+                                    "sci_name"
+                                ]
+                elif report_type == "krakenuniq":
+                    fieldnames = [ 
+                                    "pct_of_reads",
+                                    "num_reads",
+                                    "reads_exc_children",
+                                    "uniq_kmers",
+                                    "kmer_dups",
+                                    "cov_of_clade_kmers",
+                                    "NCBI_tax_ID",
+                                    "rank",
+                                    "sci_name"
+                                ]
+                else:
+                    continue #never reached since we fall back to kraken above
+
+                row = next(csv.DictReader([line.strip().rstrip('\n')], fieldnames=fieldnames, dialect="kraken_report"))
+
+                try:
+                    indent_of_line = indent_len(row["sci_name"])
+                except AttributeError as e:
+                    log.warning("Report type: '{}'".format(report_type))
+                    log.warning("Issue with line {}: '{}'".format(lineno,line.strip().rstrip('\n')))
+                    log.warning("From file: {}".format(f))
+                # remove leading/trailing whitespace from each item
+                row = { k:v.strip() for k, v in row.items()}
+
+                # rows are formatted as described above. 
+                # Kraken:
+                #   0.00  16  0   D   10239     Viruses
+                # KrakenUniq:
+                #   0.05591  2      0         13     1.85  NA   10239  superkingdom  Viruses
+
+                # if the root-level bins (root, unclassified) should be included, do so, but bypass normal
+                # stateful parsing logic since root does not have a distinct rank level
+                if row["sci_name"].lower() in ["root","unclassified"] and include_root:
+                    sample_root_summary[row["sci_name"]] = collections.OrderedDict()
+                    sample_root_summary[row["sci_name"]][row["sci_name"]] = Abundance(float(row["pct_of_reads"]), int(row["num_reads"]),row.get("kmers",None),row.get("dup",None),row.get("cov",None))
+                    continue
+
+                if indent_of_line <= indent_of_selection:
+                    should_process = False
+                    indent_of_selection=-1
+
+                if indent_of_selection == -1:
+                    if row["sci_name"].lower() in tax_headings_copy:
+                        tax_headings_copy.remove(row["sci_name"].lower())
+
+                        should_process = True
+                        indent_of_selection = indent_of_line
+                        currently_being_processed = row["sci_name"]
+                        sample_summary[currently_being_processed] = collections.OrderedDict()
+                        if row["rank"] == rank_code(taxlevel_focus) or row["rank"].lower().replace(" ","") == taxlevel_focus.lower().replace(" ",""):
+                            same_level = True
+                        if row["rank"] in ("-","no rank"):
+                            log.warning("Non-taxonomic parent level selected")
+
+                if should_process:
+                    # skip "-" rank levels since they do not occur at the sample level
+                    # otherwise include the taxon row if the rank matches the desired level of focus
+                    if (row["rank"] not in ("-","no rank") and (rank_code(taxlevel_focus) == row["rank"] or row["rank"].lower().replace(" ","") == taxlevel_focus.lower().replace(" ","")) ):
+                        if int(row["num_reads"])>=count_threshold:
+                            sample_summary[currently_being_processed][row["sci_name"]] = Abundance(float(row["pct_of_reads"]), int(row["num_reads"]),row.get("kmers",None),row.get("dup",None),row.get("cov",None))
+
+
+        for k,taxa in sample_summary.items():
+            sample_summary[k] = collections.OrderedDict(sorted(taxa.items(), key=lambda item: (item[1][1]) , reverse=True)[:top_n_entries])
+
+            if len(list(sample_summary[k].items()))>0:
+                log.info("{f}: most abundant among {heading} at the {level} level: "
+                            "\"{name}\" with {reads} reads ({percent:.2%} of total); "
+                            "included since >{threshold} read{plural}".format(
+                                                                          f=f,
+                                                                          heading=k,
+                                                                          level=taxlevel_focus,
+                                                                          name=list(sample_summary[k].items())[0][0],
+                                                                          reads=list(sample_summary[k].items())[0][1].count,
+                                                                          percent=list(sample_summary[k].items())[0][1].percent/100.0,
+                                                                          threshold=count_threshold,
+                                                                          plural="s" if count_threshold>1 else "" )
+                )
+
+        if include_root:
+            # include root-level bins (root, unclassified) in the returned data
+            for k,taxa in sample_root_summary.items():
+                assert (k not in sample_summary), "{k} already in sample summary".format(k=k)
+                sample_summary[k] = taxa
+        samples[sample_name] = sample_summary
+
+    if json_out != None:
+        json_summary = json.dumps(samples, sort_keys=True, indent=4, separators=(',', ': '))
+        json_out.write(json_summary)
+        json_out.close()
+
+
+    if csv_out != None:
+
+        # if we're writing out at the same level as the query header
+        # write out the fractions and counts
+        if same_level or no_hist:
+
+            fieldnames = set()
+            for sample, taxa in samples.items():
+                for heading,taxon in taxa.items():
+                    if len(taxon):
+                        for k in taxon.keys():
+                            fieldnames |= set([k+"-pt",k+"-ct"])
+
+            heading_columns = ["sample"]
+            if include_root:
+                root_fields = ["root-pt","root-ct","unclassified-pt","unclassified-ct"]
+                fieldnames -= set(root_fields)
+                heading_columns += root_fields
+
+            writer = csv.DictWriter(csv_out, restval=0 if zero_fill else '', fieldnames=heading_columns+sorted(list(fieldnames)))
+            writer.writeheader()
+
+            for sample, taxa in samples.items():
+                sample_dict = {}
+                sample_dict["sample"] = sample
+                for heading,taxon in taxa.items():
+                    for entry in taxon.keys():
+                        sample_dict[entry+"-pt"] = taxon[entry].percent
+                        sample_dict[entry+"-ct"] = taxon[entry].count
+                writer.writerow(sample_dict)
+
+
+            csv_out.close()
+
+        # otherwise write out a histogram
+        else:
+            count = 0
+            summary_counts = collections.defaultdict(dict)
+            for sample, totals in samples.items():
+                for heading,taxa in totals.items():
+                    for taxon in taxa.keys():
+                        if taxon not in summary_counts[heading].keys():
+                            summary_counts[heading][taxon] = 1
+                        else:
+                            summary_counts[heading][taxon] += 1
+
+            for k,taxa in summary_counts.items():
+                summary_counts[k] = collections.OrderedDict(sorted(taxa.items(), key=lambda item: (item[1]) , reverse=True))
+
+
+            fieldnames = ["heading","taxon","num_samples"]
+            writer = csv.DictWriter(csv_out, restval=0 if zero_fill else '', fieldnames=fieldnames)
+            writer.writeheader()
+
+            for heading,taxa_counts in summary_counts.items():
+                writer.writerows([{"heading":heading,"taxon":taxon,"num_samples":count} for taxon,count in taxa_counts.items()])
+
+            csv_out.close()
+
+
+__commands__.append(('taxlevel_plurality', parser_kraken_taxlevel_plurality))
+
+
 def parser_krona_build(parser=argparse.ArgumentParser()):
     parser.add_argument('db', help='Krona taxonomy database output directory.')
     parser.add_argument('--taxdump_tar_gz', help='NCBI taxdump.tar.gz file', default=None)

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1492,11 +1492,14 @@ def taxlevel_plurality(summary_file, tax_heading, out_report):
         assert keeper_rows[0]["taxon_sci_name"].lower() == tax_heading.lower()
         keepers_sorted = enumerate(sorted(keeper_rows[1:], key=lambda row:int(row["reads_excl_children"]), reverse=True))
         for i, hit in keepers_sorted:
-            outrow = {'order_within_focal': i+1, 'focal_taxon_name':keeper_rows[0]["taxon_sci_name"], 'focal_taxon_count':keeper_rows[0]["reads_cumulative"], 'pct_of_focal': float(row["reads_excl_children"]) / float(keeper_rows[0]["reads_cumulative"])}
+            outrow = {  'order_within_focal': i+1,
+                        'focal_taxon_name':keeper_rows[0]["taxon_sci_name"],
+                        'focal_taxon_count':keeper_rows[0]["reads_cumulative"],
+                        'pct_of_focal': 100.0 * float(hit["reads_excl_children"]) / float(keeper_rows[0]["reads_cumulative"])}
             for k in ("pct_of_total", "reads_cumulative", "reads_excl_children", "taxon_rank", "taxon_id", "taxon_sci_name"):
                 outrow[k] = hit[k]
             out.append(outrow)
-            break # maybe some day emit more than just the top one
+            #break # maybe some day emit more than just the top one
 
     # write outputs
     with util.file.open_or_gzopen(out_report, 'wt') as outf:

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1408,11 +1408,12 @@ def parser_kraken_taxlevel_plurality(parser=argparse.ArgumentParser()):
     parser.add_argument('summary_file', help='input Kraken-format summary text file with tab-delimited taxonomic levels.')
     parser.add_argument('tax_heading', help='The taxonomic heading to analyze.')
     parser.add_argument('out_report', help='tab-delimited output file.')
+    parser.add_argument('--min_reads', type=int, dest="min_reads", help='Only include hits with more than min_reads (default: %(default)s)', default=1)
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
     util.cmd.attach_main(parser, taxlevel_plurality, split_args=True)
     return parser
 
-def taxlevel_plurality(summary_file, tax_heading, out_report):
+def taxlevel_plurality(summary_file, tax_heading, out_report, min_reads):
     """
         Identifies the most abundant taxon (of any rank) contributing to a node of interest in the taxonomic tree.
         It is intended to highlight the primary contributor of taxonomic signal within a taxonomic category of interest,
@@ -1498,8 +1499,8 @@ def taxlevel_plurality(summary_file, tax_heading, out_report):
                         'pct_of_focal': 100.0 * float(hit["reads_excl_children"]) / float(keeper_rows[0]["reads_cumulative"])}
             for k in ("pct_of_total", "reads_cumulative", "reads_excl_children", "taxon_rank", "taxon_id", "taxon_sci_name"):
                 outrow[k] = hit[k]
-            out.append(outrow)
-            #break # maybe some day emit more than just the top one
+            if int(outrow['reads_excl_children']) >= min_reads:
+                out.append(outrow)
 
     # write outputs
     with util.file.open_or_gzopen(out_report, 'wt') as outf:

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1419,244 +1419,91 @@ def taxlevel_plurality(summary_file, tax_heading, out_report):
         for example, the most abundant virus among all viruses.
     """
 
-    samples = {}
-    same_level = False
+    keeper_rows = []
+    with util.file.open_or_gzopen(summary_file, 'rt') as inf:
+        report_type=None
+        should_process = False
+        indent_of_selection = -1
+        def indent_len(in_string):
+            return len(in_string)-len(in_string.lstrip())
+        for lineno, line in enumerate(inf):
+            if len(line.rstrip('\r\n').strip()) == 0 or ( report_type != None and line.startswith("#") or line.startswith("%")):
+                continue
 
-    Abundance = collections.namedtuple("Abundance", "percent,count,kmers,dup,cov")
+            if not report_type and "KrakenUniq" in line:
+                report_type="krakenuniq"
+                continue
+            elif not report_type:
+                report_type="kraken"
 
-    def indent_len(in_string):
-        return len(in_string)-len(in_string.lstrip())
+            csv.register_dialect('kraken_report', quoting=csv.QUOTE_MINIMAL, delimiter="\t")
+            if report_type == "kraken":
+                fieldnames = [  "pct_of_total",
+                                "reads_cumulative",
+                                "reads_excl_children",
+                                "taxon_rank",
+                                "taxon_id",
+                                "taxon_sci_name"
+                            ]
+            elif report_type == "krakenuniq":
+                fieldnames = [  "pct_of_total",
+                                "reads_cumulative",
+                                "reads_excl_children",
+                                "uniq_kmers",
+                                "kmer_dups",
+                                "cov_of_clade_kmers",
+                                "taxon_id",
+                                "taxon_rank",
+                                "taxon_sci_name"
+                            ]
+            else:
+                continue #never reached since we fall back to kraken above
 
-    for f in list(summary_files_in):
-        sample_name, extension = os.path.splitext(f)
-        sample_summary = {}
-        sample_root_summary = {}
-        tax_headings_copy = [s.lower() for s in tax_headings]
+            row = next(csv.DictReader([line.strip().rstrip('\n')], fieldnames=fieldnames, dialect="kraken_report"))
 
-        # -----------------------------------------------------------------
-        # KrakenUniq has two lines prefixed by '#', a blank line,
-        # and then a TSV header beginning with "%". The column fields are:
-        # (NB:field names accurate, but space-separated in this comment 
-        # for readability here)
-        #   %        reads  taxReads  kmers  dup   cov  taxID  rank          taxName
-        #   0.05591  2      0         13     1.85  NA   10239  superkingdom  Viruses
-        #
-        # Where the fields are:
-        #   %:
-        #   reads:
-        #   taxReads:
-        #   kmers: number of unique k-mers
-        #   dup: average number of times each unique k-mer has been seen
-        #   cov: coverage of the k-mers of the clade in the database
-        #   taxID: 
-        #   rank: row["rank"]; A rank code (see list below)
-        #   taxName: row["sci_name"]; indented scientific name
-        #
-        # Taxonomic ranks used by KrakenUniq include:
-        #   unknown, no rank, sequence, assembly, subspecies, 
-        #   species, species subgroup, species group, subgenus, 
-        #   genus, tribe, subfamily, family, superfamily, parvorder, 
-        #   infraorder, suborder, order, superorder, parvclass, 
-        #   infraclass, subclass, class, superclass, subphylum, 
-        #   phylum, kingdom, superkingdom, root
-        #
-        #   via: https://github.com/fbreitwieser/krakenuniq/blob/a8b4a2dbf50553e02d3cab3c32f93f91958aa575/src/taxdb.hpp#L96-L131
-        # -----------------------------------------------------------------
-        # Kraken (standard) reports lack header lines. 
-        # (NB:field names below are only for reference. Space-separated for 
-        # readability here)
-        #   %     reads  taxReads  rank  taxID      taxName
-        #   0.00  16     0         D     10239      Viruses
-        #
-        # Where the fields are:
-        #   %:        row["pct_of_reads"]; Percentage of reads covered by the clade rooted at this taxon
-        #   reads:    row["num_reads"]; Number of reads covered by the clade rooted at this taxon
-        #   taxReads: row["reads_exc_children"]; Number of reads assigned directly to this taxon
-        #   rank:     row["rank"]; A rank code, indicating (U)nclassified, (D)omain, (K)ingdom, (P)hylum, (C)lass, (O)rder, (F)amily, (G)enus, or (S)pecies. All other ranks are simply '-'.
-        #   taxID:    row["NCBI_tax_ID"]; NCBI taxonomy ID
-        #   taxName:  row["sci_name"]; indented scientific name
-        # -----------------------------------------------------------------
+            try:
+                indent_of_line = indent_len(row["sci_name"])
+            except AttributeError as e:
+                log.warning("Report type: '{}'".format(report_type))
+                log.warning("Issue with line {}: '{}'".format(lineno,line.strip().rstrip('\n')))
+                log.warning("From file: {}".format(f))
+            # remove leading/trailing whitespace from each item
+            row = { k:v.strip() for k, v in row.items()}
 
+            if indent_of_line <= indent_of_selection:
+                should_process = False
+                indent_of_selection=-1
 
-        with util.file.open_or_gzopen(f, 'rt') as inf:
-            report_type=None
-            should_process = False
-            indent_of_selection = -1
-            currently_being_processed = ""
-            for lineno, line in enumerate(inf):
-                if len(line.rstrip('\r\n').strip()) == 0 or ( report_type != None and line.startswith("#") or line.startswith("%")):
-                    continue
+            if indent_of_selection == -1:
+                if row["sci_name"].lower() == tax_heading.lower():
+                    should_process = True
+                    indent_of_selection = indent_of_line
 
-                # KrakenUniq is mentioned on the first line of
-                # summary reports created by KrakenUniq
-                if not report_type and "KrakenUniq" in line:
-                    report_type="krakenuniq"
-                    continue
-                elif not report_type:
-                    report_type="kraken"                
+            if should_process:
+                keeper_rows.append(row)
 
-                csv.register_dialect('kraken_report', quoting=csv.QUOTE_MINIMAL, delimiter="\t")
-                if report_type == "kraken":
-                    fieldnames = [ "pct_of_reads",
-                                    "num_reads",
-                                    "reads_exc_children",
-                                    "rank",
-                                    "NCBI_tax_ID",
-                                    "sci_name"
-                                ]
-                elif report_type == "krakenuniq":
-                    fieldnames = [ 
-                                    "pct_of_reads",
-                                    "num_reads",
-                                    "reads_exc_children",
-                                    "uniq_kmers",
-                                    "kmer_dups",
-                                    "cov_of_clade_kmers",
-                                    "NCBI_tax_ID",
-                                    "rank",
-                                    "sci_name"
-                                ]
-                else:
-                    continue #never reached since we fall back to kraken above
+    # find the top hits within the focal taxon (if any)
+    out = []
+    if not keeper_rows:
+        # we didn't find anything under the tax_heading of interest
+        out.append({'order_within_focal':0, 'focal_taxon_name':tax_heading, 'focal_taxon_count':0, 'pct_of_focal':0.0, 'pct_of_total':0.0, 'reads_cumulative':0, 'reads_excl_children':0, 'taxon_rank':'', 'taxon_id':'', 'taxon_sci_name':''})
+    else:
+        # find the most abundant taxon classified underneath (but not including) the tax_heading 
+        assert keeper_rows[0]["sci_name"].lower() == tax_heading.lower()
+        keepers_sorted = enumerate(sorted(keeper_rows[1:], key=lambda row:int(row["reads_excl_children"]), reverse=True))
+        for i, hit in keepers_sorted:
+            outrow = {'order_within_focal': i+1, 'focal_taxon_name':keeper_rows[0]["sci_name"], 'focal_taxon_count':keeper_rows[0]["reads_cumulative"], 'pct_of_focal': float(row["reads_excl_children"]) / float(keeper_rows[0]["reads_cumulative"])}
+            for k in ("pct_of_total", "reads_cumulative", "reads_excl_children", "taxon_rank", "taxon_id", "taxon_sci_name"):
+                outrow[k] = hit[k]
+            out.append(outrow)
+            break # maybe some day emit more than just the top one
 
-                row = next(csv.DictReader([line.strip().rstrip('\n')], fieldnames=fieldnames, dialect="kraken_report"))
-
-                try:
-                    indent_of_line = indent_len(row["sci_name"])
-                except AttributeError as e:
-                    log.warning("Report type: '{}'".format(report_type))
-                    log.warning("Issue with line {}: '{}'".format(lineno,line.strip().rstrip('\n')))
-                    log.warning("From file: {}".format(f))
-                # remove leading/trailing whitespace from each item
-                row = { k:v.strip() for k, v in row.items()}
-
-                # rows are formatted as described above. 
-                # Kraken:
-                #   0.00  16  0   D   10239     Viruses
-                # KrakenUniq:
-                #   0.05591  2      0         13     1.85  NA   10239  superkingdom  Viruses
-
-                # if the root-level bins (root, unclassified) should be included, do so, but bypass normal
-                # stateful parsing logic since root does not have a distinct rank level
-                if row["sci_name"].lower() in ["root","unclassified"] and include_root:
-                    sample_root_summary[row["sci_name"]] = collections.OrderedDict()
-                    sample_root_summary[row["sci_name"]][row["sci_name"]] = Abundance(float(row["pct_of_reads"]), int(row["num_reads"]),row.get("kmers",None),row.get("dup",None),row.get("cov",None))
-                    continue
-
-                if indent_of_line <= indent_of_selection:
-                    should_process = False
-                    indent_of_selection=-1
-
-                if indent_of_selection == -1:
-                    if row["sci_name"].lower() in tax_headings_copy:
-                        tax_headings_copy.remove(row["sci_name"].lower())
-
-                        should_process = True
-                        indent_of_selection = indent_of_line
-                        currently_being_processed = row["sci_name"]
-                        sample_summary[currently_being_processed] = collections.OrderedDict()
-                        if row["rank"] == rank_code(taxlevel_focus) or row["rank"].lower().replace(" ","") == taxlevel_focus.lower().replace(" ",""):
-                            same_level = True
-                        if row["rank"] in ("-","no rank"):
-                            log.warning("Non-taxonomic parent level selected")
-
-                if should_process:
-                    # skip "-" rank levels since they do not occur at the sample level
-                    # otherwise include the taxon row if the rank matches the desired level of focus
-                    if (row["rank"] not in ("-","no rank") and (rank_code(taxlevel_focus) == row["rank"] or row["rank"].lower().replace(" ","") == taxlevel_focus.lower().replace(" ","")) ):
-                        if int(row["num_reads"])>=count_threshold:
-                            sample_summary[currently_being_processed][row["sci_name"]] = Abundance(float(row["pct_of_reads"]), int(row["num_reads"]),row.get("kmers",None),row.get("dup",None),row.get("cov",None))
-
-
-        for k,taxa in sample_summary.items():
-            sample_summary[k] = collections.OrderedDict(sorted(taxa.items(), key=lambda item: (item[1][1]) , reverse=True)[:top_n_entries])
-
-            if len(list(sample_summary[k].items()))>0:
-                log.info("{f}: most abundant among {heading} at the {level} level: "
-                            "\"{name}\" with {reads} reads ({percent:.2%} of total); "
-                            "included since >{threshold} read{plural}".format(
-                                                                          f=f,
-                                                                          heading=k,
-                                                                          level=taxlevel_focus,
-                                                                          name=list(sample_summary[k].items())[0][0],
-                                                                          reads=list(sample_summary[k].items())[0][1].count,
-                                                                          percent=list(sample_summary[k].items())[0][1].percent/100.0,
-                                                                          threshold=count_threshold,
-                                                                          plural="s" if count_threshold>1 else "" )
-                )
-
-        if include_root:
-            # include root-level bins (root, unclassified) in the returned data
-            for k,taxa in sample_root_summary.items():
-                assert (k not in sample_summary), "{k} already in sample summary".format(k=k)
-                sample_summary[k] = taxa
-        samples[sample_name] = sample_summary
-
-    if json_out != None:
-        json_summary = json.dumps(samples, sort_keys=True, indent=4, separators=(',', ': '))
-        json_out.write(json_summary)
-        json_out.close()
-
-
-    if csv_out != None:
-
-        # if we're writing out at the same level as the query header
-        # write out the fractions and counts
-        if same_level or no_hist:
-
-            fieldnames = set()
-            for sample, taxa in samples.items():
-                for heading,taxon in taxa.items():
-                    if len(taxon):
-                        for k in taxon.keys():
-                            fieldnames |= set([k+"-pt",k+"-ct"])
-
-            heading_columns = ["sample"]
-            if include_root:
-                root_fields = ["root-pt","root-ct","unclassified-pt","unclassified-ct"]
-                fieldnames -= set(root_fields)
-                heading_columns += root_fields
-
-            writer = csv.DictWriter(csv_out, restval=0 if zero_fill else '', fieldnames=heading_columns+sorted(list(fieldnames)))
-            writer.writeheader()
-
-            for sample, taxa in samples.items():
-                sample_dict = {}
-                sample_dict["sample"] = sample
-                for heading,taxon in taxa.items():
-                    for entry in taxon.keys():
-                        sample_dict[entry+"-pt"] = taxon[entry].percent
-                        sample_dict[entry+"-ct"] = taxon[entry].count
-                writer.writerow(sample_dict)
-
-
-            csv_out.close()
-
-        # otherwise write out a histogram
-        else:
-            count = 0
-            summary_counts = collections.defaultdict(dict)
-            for sample, totals in samples.items():
-                for heading,taxa in totals.items():
-                    for taxon in taxa.keys():
-                        if taxon not in summary_counts[heading].keys():
-                            summary_counts[heading][taxon] = 1
-                        else:
-                            summary_counts[heading][taxon] += 1
-
-            for k,taxa in summary_counts.items():
-                summary_counts[k] = collections.OrderedDict(sorted(taxa.items(), key=lambda item: (item[1]) , reverse=True))
-
-
-            fieldnames = ["heading","taxon","num_samples"]
-            writer = csv.DictWriter(csv_out, restval=0 if zero_fill else '', fieldnames=fieldnames)
-            writer.writeheader()
-
-            for heading,taxa_counts in summary_counts.items():
-                writer.writerows([{"heading":heading,"taxon":taxon,"num_samples":count} for taxon,count in taxa_counts.items()])
-
-            csv_out.close()
-
+    # write outputs
+    with util.file.open_or_gzopen(out_report, 'wt') as outf:
+        header = ('focal_taxon_name', 'focal_taxon_count', 'order_within_focal', 'pct_of_focal', 'pct_of_total', 'reads_cumulative', 'reads_excl_children', 'taxon_rank', 'taxon_id', 'taxon_sci_name')
+        writer = csv.DictWriter(outf, header, delimiter='\t', dialect=csv.unix_dialect, quoting=csv.QUOTE_MINIMAL)
+        writer.writeheader()
+        writer.writerows(out)
 
 __commands__.append(('taxlevel_plurality', parser_kraken_taxlevel_plurality))
 

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -1409,7 +1409,7 @@ def parser_kraken_taxlevel_plurality(parser=argparse.ArgumentParser()):
     parser.add_argument('tax_heading', help='The taxonomic heading to analyze.')
     parser.add_argument('out_report', help='tab-delimited output file.')
     util.cmd.common_args(parser, (('loglevel', None), ('version', None), ('tmp_dir', None)))
-    util.cmd.attach_main(parser, taxlevel_summary, split_args=True)
+    util.cmd.attach_main(parser, taxlevel_plurality, split_args=True)
     return parser
 
 def taxlevel_plurality(summary_file, tax_heading, out_report):

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -154,6 +154,13 @@ class TaxonomyDb(object):
                 ranks[taxid] = rank
         return ranks, parents
 
+    def get_ordered_ancestors(self, taxid):
+        ''' returns all ancestors of a taxid in proximity order: [parent, grandparent, greatgrandparent, etc] '''
+        if taxid in self.parents and taxid != self.parents[taxid]:
+            return [self.parents[taxid]] + self.get_ordered_ancestors(self.parents[taxid])
+        else:
+            return []
+
     def process_blast_hits(self, hits, top_percent):
         '''Filter groups of blast hits and perform lca.
 

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -77,10 +77,13 @@ class TaxonomyDb(object):
         load_names=False
     ):
         if tax_dir:
-            gis_paths = [maybe_compressed(os.path.join(tax_dir, 'gi_taxid_nucl.dmp')),
-                         maybe_compressed(os.path.join(tax_dir, 'gi_taxid_prot.dmp'))]
-            nodes_path = maybe_compressed(os.path.join(tax_dir, 'nodes.dmp'))
-            names_path = maybe_compressed(os.path.join(tax_dir, 'names.dmp'))
+            if load_gis and not gis:
+                gis_paths = [maybe_compressed(os.path.join(tax_dir, 'gi_taxid_nucl.dmp')),
+                            maybe_compressed(os.path.join(tax_dir, 'gi_taxid_prot.dmp'))]
+            else:
+                gis_paths = []
+            nodes_path = load_nodes and maybe_compressed(os.path.join(tax_dir, 'nodes.dmp')) or None
+            names_path = load_names and maybe_compressed(os.path.join(tax_dir, 'names.dmp')) or None
         self.tax_dir = tax_dir
         self.gis_paths = gis_paths
         self.nodes_path = nodes_path
@@ -718,7 +721,7 @@ def filter_taxids_to_focal_hits(taxids_tsv, focal_report_tsv, taxdb_dir, min_rea
     '''
 
     # load taxonomy database structure
-    taxdb = TaxonomyDb(tax_dir=taxdb_dir, load_nodes=True)
+    taxdb = TaxonomyDb(tax_dir=taxdb_dir, load_nodes=True, load_gis=False)
 
     # load focal hits
     hits = set()

--- a/test/unit/test_metagenomics.py
+++ b/test/unit/test_metagenomics.py
@@ -231,6 +231,10 @@ def test_translate_gi_to_tax_id(taxa_db_simple):
     assert taxa_db_simple.translate_gi_to_tax_id(blast1) == expected
 
 
+def test_ancestor_lookup(taxa_db_simple):
+    assert taxa_db_simple.get_ordered_ancestors(4) == [3, 2, 1]
+
+
 def test_kraken_dfs_report(taxa_db):
     hits = Counter({1: 101, 3: 103, 10: 105, 12: 107})
 

--- a/test/unit/test_metagenomics.py
+++ b/test/unit/test_metagenomics.py
@@ -193,7 +193,7 @@ def test_blast_lca(taxa_db_simple, simple_m8):
     """)
     out = StringIO()
     with simple_m8 as f:
-        metagenomics.blast_lca(taxa_db_simple, f, out, paired=True)
+        taxa_db_simple.blast_lca(f, out, paired=True)
         out.seek(0)
         assert out.read() == expected
 
@@ -228,7 +228,7 @@ def test_translate_gi_to_tax_id(taxa_db_simple):
 
     tup[1] = 5
     expected = metagenomics.BlastRecord(*tup)
-    assert metagenomics.translate_gi_to_tax_id(taxa_db_simple, blast1) == expected
+    assert taxa_db_simple.translate_gi_to_tax_id(blast1) == expected
 
 
 def test_kraken_dfs_report(taxa_db):
@@ -243,7 +243,7 @@ def test_kraken_dfs_report(taxa_db):
     25.72\t107\t0\t-\t8\t        eight
     25.72\t107\t107\tS\t12\t          twelve
     ''')
-    report = metagenomics.kraken_dfs_report(taxa_db, hits)
+    report = taxa_db.kraken_dfs_report(hits)
     text_report = '\n'.join(list(report)) + '\n'
     assert text_report == expected
 


### PR DESCRIPTION
Add a new command to `metagenomics.py` called `taxlevel_plurality` (inspired by `taxlevel_summary`) that takes a kraken (or kraken2 or krakenuniq) summary report as input and reports on the top taxa identified under a focal taxon of interest (e.g. "Viruses"). This emits a tabular file ranked in descending order of the taxa with the highest read counts (not including children).

Add new command to `metagenomics.py` called `filter_taxids_to_focal_hits` to reduce a list of taxids to those related to outputs from taxlevel_plurality.

Also a few other unrelated bits included in this PR:
 - build updates: remove scheduled builds from GHActions (they don't like it and auto-disable builds if we don't touch the codebase much), add merge_group functionality, bump some versions of GHActions builders that are deprecated
 - update viral-core 2.2.3 to 2.2.4
 - clean up a bunch of stray top level python methods in metagenomics.py and move into the TaxonomyDb class for proper hygiene 