### PR TITLE
Add minimap2-based read depletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.5.13
+FROM quay.io/broadinstitute/viral-core:2.5.14
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.5.1
+FROM quay.io/broadinstitute/viral-core:2.5.13
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 


### PR DESCRIPTION
## Summary

- Add `deplete_minimap2_bam` command for minimap2-based read depletion
- Bump viral-core from 2.5.1 to 2.5.14 (includes new `Minimap2.idxstats()` method from viral-core PR #148)

## Details

### New deplete_minimap2_bam command

Implements a new depletion method using the PAF-based `Minimap2.idxstats()` method to identify and remove reads matching reference databases. This provides a faster alternative to existing depletion methods (blastn, bmtagger, bwa).

**Features:**
- Uses PAF output format for faster alignment (no SAM/BAM generation)
- Supports multiple reference FASTA files via `multi_db_deplete_bam` helper
- Follows established patterns from `deplete_blastn_bam`, `deplete_bmtagger_bam`, and `deplete_bwa_bam`

**Usage:**
```bash
# Single reference
taxon_filter.py deplete_minimap2_bam input.bam reference.fasta output.bam

# Multiple references
taxon_filter.py deplete_minimap2_bam input.bam ref1.fasta ref2.fasta output.bam --threads 4
```

### viral-core updates

- `50372aec` bump viral-core 2.5.1 to 2.5.13
- `d3a8dca1` bump viral-core to 2.5.14

These updates include the new `Minimap2.idxstats()` method with optional `outReadlist` parameter used by this implementation.

## Test plan

- [x] `test_deplete_minimap2_bam` - Basic depletion removes human reads from mixed input
- [x] `test_minimap2_empty_input` - Empty BAM input produces empty output
- [x] `test_minimap2_empty_output` - All-human input results in empty output after depletion
- [x] All existing taxon_filter tests pass (21 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
