### PR TITLE
Update viral-core and use ReadIdStore.add_from_readlist for file-based read ID loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.5.19
+FROM quay.io/broadinstitute/viral-core:2.5.20
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 

--- a/classify/kmc.py
+++ b/classify/kmc.py
@@ -277,8 +277,7 @@ class KmcTool(tools.Tool):
                 # Load passing read names into ReadIdStore and filter BAM (keep matching reads)
                 db_path = os.path.join(t_dir, 'read_ids.db')
                 with read_utils.ReadIdStore(db_path) as store:
-                    with open(passing_read_names, 'rt') as f:
-                        store.extend(line.strip() for line in f if line.strip())
+                    store.add_from_readlist(passing_read_names)
                     store.filter_bam_by_ids(in_reads, out_reads, include=True)
         # end: with util.file.tmp_dir(suffix='kmcfilt') as t_dir
     # end: def filter_reads(self, kmer_db, in_reads, out_reads, db_min_occs=1, db_max_occs=util.misc.MAX_INT32, ...)

--- a/taxon_filter.py
+++ b/taxon_filter.py
@@ -333,8 +333,7 @@ def deplete_bmtagger_bam(inBam, db, outBam, srprism_memory=7168):
                 with util.file.tmp_dir(suffix='_bmtagger_filter') as filter_tmpdir:
                     db_path = os.path.join(filter_tmpdir, 'read_ids.db')
                     with read_utils.ReadIdStore(db_path) as store:
-                        with open(matchesFile, 'rt') as f:
-                            store.extend(line.strip() for line in f if line.strip())
+                        store.add_from_readlist(matchesFile)
                         store.filter_bam_by_ids(inBam, outBam, include=False)
                 os.unlink(matchesFile)
 
@@ -539,8 +538,7 @@ def deplete_blastn_bam(inBam, db, outBam, threads=None, chunkSize=1000000):
     with util.file.tmp_dir(suffix='_blastn_filter') as filter_tmpdir:
         db_path = os.path.join(filter_tmpdir, 'read_ids.db')
         with read_utils.ReadIdStore(db_path) as store:
-            with open(blast_hits, 'rt') as f:
-                store.extend(line.strip() for line in f if line.strip())
+            store.add_from_readlist(blast_hits)
             store.filter_bam_by_ids(inBam, outBam, include=False)
     os.unlink(blast_hits)
 
@@ -731,8 +729,7 @@ def deplete_minimap2_bam(inBam, db, outBam, threads=None):
 
         # Load hit list into ReadIdStore and filter BAM (exclude matching reads)
         with read_utils.ReadIdStore(db_path) as store:
-            with open(hitList, 'rt') as f:
-                store.extend(line.strip() for line in f if line.strip())
+            store.add_from_readlist(hitList)
             store.filter_bam_by_ids(inBam, outBam, include=False)
 
 


### PR DESCRIPTION
## Summary
- Update viral-core 2.5.19 to 2.5.20 which introduces significant performance improvements (or counter-regressions) to `ReadIdStore.filter_bam_by_ids`
- Replace manual file reading pattern with the new `add_from_readlist` method from viral-core 2.5.20
- Updates 4 locations: `deplete_bmtagger_bam`, `deplete_blastn_bam`, `deplete_minimap2_bam`, and `Kmc.filter_reads`
- Simplifies code by using the new helper method instead of manual `with open() as f: store.extend(...)` pattern

## Test plan
- [ ] Run unit tests for taxon_filter: `pytest test/unit/test_taxon_filter.py`
- [ ] Run unit tests for kmc: `pytest test/unit/test_kmc.py`
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)