### PR TITLE
Bump viral-core and fix CI race condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ env:
 jobs:
   build_docker:
     runs-on: ubuntu-24.04
+    outputs:
+      docker_tag: ${{ steps.docker_tag.outputs.tag }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
@@ -129,6 +131,12 @@ jobs:
       - name: Deploy docker image
         run: |
           github_actions_ci/deploy-docker.sh
+      - name: Output docker tag for downstream jobs
+        id: docker_tag
+        run: |
+          DOCKER_TAG=$(github_actions_ci/list-docker-tags.sh | tail -1)
+          echo "tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
+          echo "Docker tag for downstream jobs: $DOCKER_TAG"
       - name: store tag ID in cache
         run: |
           mkdir -p $CACHE_DIR
@@ -138,49 +146,16 @@ jobs:
     needs: build_docker
     runs-on: ubuntu-24.04
     env:
-      GITHUB_ACTIONS_PYTHON_VERSION: "3.10"
       PYTEST_ADDOPTS: "-rsxX --durations=25 --fixture-durations=10 --junit-xml=pytest.xml --cov-config=.coveragerc --cov-report xml:coverage.xml --cov-report= --cov kmer_utils --cov metagenomics --cov taxon_filter --cov classify"
+      DOCKER_TAG: ${{ needs.build_docker.outputs.docker_tag }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
-      # fetch git tags (tagged releases) because 
-      # actions/checkout@v3 does either a full checkout or a shallow checkout without tags
-      - name: fetch tags
-        run: git fetch --prune --unshallow --tags
-      - name: Programmatic environment setup
-        run: |
-          set -e -x
-          # $GITHUB_ENV is available for subsequent steps
-          GITHUB_ACTIONS_TAG=$(git describe --tags --exact-match && sed 's/^v//g' || echo '')
-          echo "GITHUB_ACTIONS_TAG=$GITHUB_ACTIONS_TAG" >> $GITHUB_ENV
-          # 
-          # Set GITHUB_ACTIONS_BRANCH
-          # TRAVIS_BRANCH: (via https://docs.travis-ci.com/user/environment-variables/ )
-          #   for push builds, or builds not triggered by a pull request, this is the name of the branch.
-          #   for builds triggered by a pull request this is the name of the branch targeted by the pull request.
-          #   for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).
-          # if GITHUB_ACTIONS_PULL_REQUEST_BRANCH is set, this is a pull request build
-          if [[ $GITHUB_ACTIONS_PULL_REQUEST_BRANCH ]]; then
-            GITHUB_ACTIONS_BRANCH=${GITHUB_ACTIONS_BASE_REF##*/}
-          # if event_name=="release", this is a tagged build
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_TAG
-          else
-            GITHUB_ACTIONS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          fi
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH"
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH" >> $GITHUB_ENV
-      - name: install python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "${{ env.GITHUB_ACTIONS_PYTHON_VERSION }}"
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: pull docker image
         run: |
           set -e -x
-          DOCKER_TAG=$(github_actions_ci/list-docker-tags.sh | tail -1)
-          echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "pulling $DOCKER_TAG"
           docker pull $DOCKER_TAG
           mkdir coverage
@@ -198,43 +173,16 @@ jobs:
   test_docs:
     needs: build_docker
     runs-on: ubuntu-24.04
+    env:
+      DOCKER_TAG: ${{ needs.build_docker.outputs.docker_tag }}
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-      # fetch git tags (tagged releases) because 
-      # actions/checkout@v4 does either a full checkout or a shallow checkout without tags
-      - name: fetch tags
-        run: git fetch --prune --unshallow --tags
-      - name: Programmatic environment setup
-        run: |
-          set -e -x
-          # $GITHUB_ENV is available for subsequent steps
-          GITHUB_ACTIONS_TAG=$(git describe --tags --exact-match && sed 's/^v//g' || echo '')
-          echo "GITHUB_ACTIONS_TAG=$GITHUB_ACTIONS_TAG" >> $GITHUB_ENV
-          # 
-          # Set GITHUB_ACTIONS_BRANCH
-          # TRAVIS_BRANCH: (via https://docs.travis-ci.com/user/environment-variables/ )
-          #   for push builds, or builds not triggered by a pull request, this is the name of the branch.
-          #   for builds triggered by a pull request this is the name of the branch targeted by the pull request.
-          #   for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).
-          # if GITHUB_ACTIONS_PULL_REQUEST_BRANCH is set, this is a pull request build
-          if [[ $GITHUB_ACTIONS_PULL_REQUEST_BRANCH ]]; then
-            GITHUB_ACTIONS_BRANCH=${GITHUB_ACTIONS_BASE_REF##*/}
-          # if event_name=="release", this is a tagged build
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_TAG
-          else
-            GITHUB_ACTIONS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          fi
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH"
-          echo "GITHUB_ACTIONS_BRANCH=$GITHUB_ACTIONS_BRANCH" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: pull docker image
         run: |
           set -e -x
-          DOCKER_TAG=$(github_actions_ci/list-docker-tags.sh | tail -1)
-          echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "pulling $DOCKER_TAG"
           docker pull $DOCKER_TAG
       - name: test building docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/broadinstitute/viral-core:2.5.20
+FROM quay.io/broadinstitute/viral-core:2.5.21
 
 LABEL maintainer "viral-ngs@broadinstitute.org"
 

--- a/github_actions_ci/list-docker-tags.sh
+++ b/github_actions_ci/list-docker-tags.sh
@@ -29,6 +29,13 @@ elif [ -n "$GITHUB_ACTIONS_PULL_REQUEST_BRANCH" ]; then
 	DOCKER_SHORT_TAG="$BRANCH_NAME-pull_request"
 	DOCKER_LONG_TAG="$(git describe --tags --always | sed s/^v//)-$(echo $DOCKER_SHORT_TAG)"
 	#DOCKER_LONG_TAG="$(git describe --tags --always | perl -lape 's/^v?(\S+)-(\d+)-g(\S+)/$1-beta$2-g$3/')-$(echo $BRANCH_NAME | sed 's/-/_/g')"
+elif [[ "$GITHUB_ACTIONS_BRANCH" == gh-readonly-queue/* ]]; then
+	# this is a merge queue commit (about to become master)
+	DOCKER_REPO=$DOCKER_REPO_DEV
+	# Extract PR number from branch name for tag clarity
+	PR_NUM=$(echo "$GITHUB_ACTIONS_BRANCH" | sed 's/.*pr-\([0-9]*\)-.*/\1/')
+	DOCKER_SHORT_TAG="merge-queue-pr-$PR_NUM"
+	DOCKER_LONG_TAG="$(git describe --tags --always | sed s/^v//)-merge-queue-pr-$PR_NUM"
 elif [[ "$GITHUB_ACTIONS_BRANCH" == "master" ]]; then
 	# this is a master branch commit (e.g. merged pull request)
 	DOCKER_REPO=$DOCKER_REPO_PROD


### PR DESCRIPTION
## Summary
- Bump viral-core dependency
- Fix CI race condition where downstream test jobs could fail if a release tag is created between `build_docker` and `test_in_docker`/`test_docs` jobs

The race condition fix passes the Docker tag as a job output from `build_docker` to downstream jobs, ensuring they pull the exact image that was built rather than recalculating the tag via `git describe` (which could return a different value if tags changed).

This mirrors the fix in https://github.com/broadinstitute/viral-core/pull/162

## Test plan
- [ ] CI passes with the new workflow structure
- [ ] Docker image is correctly pulled by downstream jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)