### PR TITLE
Disable kaiju to remove broad-viral conda channel dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM quay.io/broadinstitute/viral-core:2.5.21
 LABEL maintainer "viral-ngs@broadinstitute.org"
 
 ENV VIRAL_CLASSIFY_PATH=$INSTALL_PATH/viral-classify \
-	PATH="$PATH:$MINICONDA_PATH/envs/env2/bin:$MINICONDA_PATH/envs/env3/bin:$MINICONDA_PATH/envs/env4/bin"
+	PATH="$PATH:$MINICONDA_PATH/envs/env2/bin:$MINICONDA_PATH/envs/env3/bin:$MINICONDA_PATH/envs/env4/bin" \
+	CONDA_CHANNEL_STRING="--override-channels -c conda-forge -c bioconda"
 
 COPY requirements-conda.txt requirements-conda-env2.txt requirements-conda-env3.txt requirements-conda-env4.txt $VIRAL_CLASSIFY_PATH/
 # install most dependencies to the main environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,12 @@ RUN $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/re
 
 # install packages with dependency incompatibilities to the third environment
 RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env3"; \
-	#conda config --set channel_priority strict; \
-	conda create -q -y -n env3; \
+	conda create -q -y -n env3 --override-channels -c conda-forge -c bioconda; \
 	$VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env3.txt
 
 # install packages with dependency incompatibilities to the 4th environment
 RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env4"; \
-	#conda config --set channel_priority strict; \
-	conda create -q -y -n env4; \
+	conda create -q -y -n env4 --override-channels -c conda-forge -c bioconda; \
 	$VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env4.txt
 
 # Copy all source code into the base repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ COPY requirements-conda.txt requirements-conda-env2.txt requirements-conda-env3.
 # install most dependencies to the main environment
 RUN $VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda.txt $VIRAL_NGS_PATH/requirements-conda.txt
 
-# install packages with dependency incompatibilities to the second environment
-RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env2"; \
-	#conda config --set channel_priority strict; \
-	conda create -q -y -n env2; \
-	$VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env2.txt
+# env2 disabled - was only used for kaiju (broad-viral channel)
+# RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env2"; \
+# 	conda create -q -y -n env2; \
+# 	$VIRAL_NGS_PATH/docker/install-conda-dependencies.sh $VIRAL_CLASSIFY_PATH/requirements-conda-env2.txt
 
 # install packages with dependency incompatibilities to the third environment
 RUN CONDA_PREFIX="$MINICONDA_PATH/envs/env3"; \

--- a/metagenomics.py
+++ b/metagenomics.py
@@ -37,7 +37,7 @@ import util.file
 import util.misc
 import read_utils
 
-import classify.kaiju
+# import classify.kaiju  # disabled: kaiju requires broad-viral conda channel
 import classify.kma
 import classify.kraken
 import classify.kraken2
@@ -936,7 +936,7 @@ def parser_krona(parser=argparse.ArgumentParser()):
     parser.add_argument('--magnitudeColumn', help='Column of magnitude. (default %(default)s)', type=int, default=None)
     parser.add_argument('--noHits', help='Include wedge for no hits.', action='store_true')
     parser.add_argument('--noRank', help='Include no rank assignments.', action='store_true')
-    parser.add_argument('--inputType', help='Handling for specialized report types.', default='tsv', choices=['tsv', 'kraken2', 'krakenuniq', 'kaiju'])
+    parser.add_argument('--inputType', help='Handling for specialized report types.', default='tsv', choices=['tsv', 'kraken2', 'krakenuniq'])  # 'kaiju' disabled
     util.cmd.common_args(parser, (('loglevel', None), ('version', None)))
     util.cmd.attach_main(parser, krona, split_args=True)
     return parser
@@ -986,18 +986,19 @@ def krona(inReports, db, outHtml, queryColumn=None, taxidColumn=None, scoreColum
                         f_out.write('{}\t{}\t{}\n'.format(taxid, tax_reads, tax_kmers))
                 to_import.append(tmp_tsv)
 
-        elif inputType == 'kaiju':
-            queryColumn=None
-            taxidColumn=1
-            scoreColumn=None
-            magnitudeColumn=2
-            for inReport in inReports:
-                tmp_tsv = util.file.mkstempfname('.tsv', directory=tmp_dir)
-                with open(tmp_tsv, 'w') as f_out:
-                    report = classify.kaiju.Kaiju().read_report(inReport)
-                    for taxid, reads in report.items():
-                        f_out.write('{}\t{}\n'.format(taxid, reads))
-                to_import.append(tmp_tsv)
+        # kaiju support disabled - requires broad-viral conda channel
+        # elif inputType == 'kaiju':
+        #     queryColumn=None
+        #     taxidColumn=1
+        #     scoreColumn=None
+        #     magnitudeColumn=2
+        #     for inReport in inReports:
+        #         tmp_tsv = util.file.mkstempfname('.tsv', directory=tmp_dir)
+        #         with open(tmp_tsv, 'w') as f_out:
+        #             report = classify.kaiju.Kaiju().read_report(inReport)
+        #             for taxid, reads in report.items():
+        #                 f_out.write('{}\t{}\n'.format(taxid, reads))
+        #         to_import.append(tmp_tsv)
 
         else:
             raise NotImplementedError
@@ -1029,23 +1030,24 @@ def krona(inReports, db, outHtml, queryColumn=None, taxidColumn=None, scoreColum
 __commands__.append(('krona', parser_krona))
 
 
-def parser_kaiju(parser=argparse.ArgumentParser()):
-    parser.add_argument('inBam', help='Input unaligned reads, BAM format.')
-    parser.add_argument('db', help='Kaiju database .fmi file.')
-    parser.add_argument('taxDb', help='Taxonomy database directory.')
-    parser.add_argument('outReport', help='Output taxonomy report.')
-    parser.add_argument('--outReads', help='Output LCA assignments for each read.')
-    util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
-    util.cmd.attach_main(parser, kaiju, split_args=True)
-    return parser
-def kaiju(inBam, db, taxDb, outReport, outReads=None, threads=None):
-    '''
-        Classify reads by the taxon of the Lowest Common Ancestor (LCA)
-    '''
-
-    kaiju_tool = classify.kaiju.Kaiju()
-    kaiju_tool.classify(db, taxDb, inBam, output_report=outReport, output_reads=outReads, num_threads=threads)
-__commands__.append(('kaiju', parser_kaiju))
+# kaiju command disabled - requires broad-viral conda channel
+# def parser_kaiju(parser=argparse.ArgumentParser()):
+#     parser.add_argument('inBam', help='Input unaligned reads, BAM format.')
+#     parser.add_argument('db', help='Kaiju database .fmi file.')
+#     parser.add_argument('taxDb', help='Taxonomy database directory.')
+#     parser.add_argument('outReport', help='Output taxonomy report.')
+#     parser.add_argument('--outReads', help='Output LCA assignments for each read.')
+#     util.cmd.common_args(parser, (('threads', None), ('loglevel', None), ('version', None), ('tmp_dir', None)))
+#     util.cmd.attach_main(parser, kaiju, split_args=True)
+#     return parser
+# def kaiju(inBam, db, taxDb, outReport, outReads=None, threads=None):
+#     '''
+#         Classify reads by the taxon of the Lowest Common Ancestor (LCA)
+#     '''
+#
+#     kaiju_tool = classify.kaiju.Kaiju()
+#     kaiju_tool.classify(db, taxDb, inBam, output_report=outReport, output_reads=outReads, num_threads=threads)
+# __commands__.append(('kaiju', parser_kaiju))
 
 
 def parser_metagenomic_report_merge(parser=argparse.ArgumentParser()):

--- a/requirements-conda-env2.txt
+++ b/requirements-conda-env2.txt
@@ -1,1 +1,1 @@
-kaiju>=1.6.3_yesimon
+# kaiju>=1.6.3_yesimon  # disabled: only package from broad-viral channel which causes CI timeouts

--- a/test/deprecated/snakemake/test_kaiju.py
+++ b/test/deprecated/snakemake/test_kaiju.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
+# DISABLED: kaiju requires broad-viral conda channel which causes CI timeouts
 
 import os
 import sys
 
 import pytest
+pytestmark = pytest.mark.skip(reason="kaiju disabled - requires broad-viral conda channel")
 
 import tools
-from test.pipelines.snakemake import snake
-from test.integration.test_kaiju import * # for pytest fixtures
+# from test.pipelines.snakemake import snake
+# from test.integration.test_kaiju import * # for pytest fixtures
 
 @pytest.mark.skipif(sys.version_info < (3, 5), reason="Python version is too old for snakemake.")
 def test_pipes(tmpdir_function, kaiju_db, taxonomy_db, krona_db, input_bam):

--- a/test/unit/fixtures.py
+++ b/test/unit/fixtures.py
@@ -3,7 +3,7 @@ import os
 from os.path import join
 import shutil
 import tools
-import classify.kaiju
+# import classify.kaiju  # disabled: kaiju requires broad-viral conda channel
 import tools.picard
 import classify.krona
 import util.file

--- a/test/unit/test_integration_kaiju.py
+++ b/test/unit/test_integration_kaiju.py
@@ -1,4 +1,8 @@
 # Integration tests for kaiju
+# DISABLED: kaiju requires broad-viral conda channel which causes CI timeouts
+import pytest
+pytestmark = pytest.mark.skip(reason="kaiju disabled - requires broad-viral conda channel")
+
 from builtins import super
 import argparse
 import binascii
@@ -11,12 +15,11 @@ import shutil
 import tempfile
 
 #import lxml.html.clean
-import pytest
 from Bio import SeqIO
 
 import metagenomics
 import tools
-import classify.kaiju
+# import classify.kaiju  # disabled
 import tools.picard
 import util.file
 import test.unit.fixtures
@@ -49,11 +52,11 @@ def sam_to_fastq():
     return tools.picard.SamToFastqTool()
 
 
-@pytest.fixture(scope='module')
-def kaiju():
-    kaiju = classify.kaiju.Kaiju()
-    kaiju.install()
-    return kaiju
+# @pytest.fixture(scope='module')
+# def kaiju():
+#     kaiju = classify.kaiju.Kaiju()
+#     kaiju.install()
+#     return kaiju
 
 
 @pytest.fixture(scope='module', params=['TestMetagenomicsSimple', 'TestMetagenomicsViralMix'])

--- a/test/unit/test_metagenomics.py
+++ b/test/unit/test_metagenomics.py
@@ -273,18 +273,19 @@ def test_krakenuniq(mocker):
     p.assert_called_with('db', ['input.bam'], num_threads=mock.ANY, filter_threshold=mock.ANY, out_reports=['output.report'], out_reads=['output.reads'])
 
 
-def test_kaiju(mocker):
-    p = mocker.patch('classify.kaiju.Kaiju.classify')
-    args = [
-        'input.bam',
-        'db.fmi',
-        'tax_db',
-        'output.report',
-        '--outReads', 'output.reads',
-    ]
-    args = metagenomics.parser_kaiju(argparse.ArgumentParser()).parse_args(args)
-    args.func_main(args)
-    p.assert_called_with('db.fmi', 'tax_db', 'input.bam', output_report='output.report', num_threads=mock.ANY, output_reads='output.reads')
+# kaiju test disabled - requires broad-viral conda channel
+# def test_kaiju(mocker):
+#     p = mocker.patch('classify.kaiju.Kaiju.classify')
+#     args = [
+#         'input.bam',
+#         'db.fmi',
+#         'tax_db',
+#         'output.report',
+#         '--outReads', 'output.reads',
+#     ]
+#     args = metagenomics.parser_kaiju(argparse.ArgumentParser()).parse_args(args)
+#     args.func_main(args)
+#     p.assert_called_with('db.fmi', 'tax_db', 'input.bam', output_report='output.report', num_threads=mock.ANY, output_reads='output.reads')
 
 
 class TestBamFilter(TestCaseWithTmp):


### PR DESCRIPTION
## Summary

- Disables kaiju support to eliminate the broad-viral conda channel dependency
- The broad-viral channel has been causing intermittent CI timeouts (e.g., the master build after PR #61 merge)
- kaiju was the only package sourced from this channel

## Changes

- requirements-conda-env2.txt: Comment out kaiju
- metagenomics.py: Comment out kaiju import, command, and krona inputType
- test files: Skip or comment out kaiju-related tests

## Notes

- The classify/kaiju.py module is preserved but not imported, allowing easy re-enablement
- The broad-viral channel configuration itself is in viral-core, but removing kaiju means nothing requires it

## Test plan

- CI tests pass (no kaiju tests should run)
- Docker build succeeds without timeout on broad-viral channel

Generated with Claude Code